### PR TITLE
chore: remove smiko from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Modmium is a chromeOS modification built to allow the freedom of an unrestricted
 * Custom bootsplashes for those who wish to install them
   * Thanks to Casper1051, Moonstone, and pilgorr for creating the default ones :D
 * Nix installer for developers to easily install packages (You can use `mix` for APT-like syntax!)
-* Comes with [Smiko](https://github.com/HavenOverflow/Smiko) pre-installed
 
 ## Getting started
 * To build modmium, see [docs/building.md](docs/building.md)


### PR DESCRIPTION
smiko was removed from the repo, we don't need it in the readme anymore.