### PR TITLE
small docs update

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -2,9 +2,9 @@
 ```sh
 git clone https://github.com/CrOSmium/modmium && cd modmium 
 # if you want to download an image and autobuild
-./build-image.sh -b <board> -v <version> <flags>
+./build-image.sh -b <board> -v <version> <build flags go here>
 # if you want to use a local image (non-destructive)
-./build-image.sh -i /path/to/image.bin <flags>
+./build-image.sh -i /path/to/image.bin <build flags go here>
 ```
 The builder also has a few other flags, which can be seen by running the script with no arguments or passing `--help`, some of which are listed here.
 * `-k`, `--kernver` (hex int, 0 to ff)

--- a/docs/building.md
+++ b/docs/building.md
@@ -2,9 +2,9 @@
 ```sh
 git clone https://github.com/CrOSmium/modmium && cd modmium 
 # if you want to download an image and autobuild
-./build-image.sh -b <board> -v <version> <build flags go here>
+./build-image.sh -b <board> -v <version> <flags>
 # if you want to use a local image (non-destructive)
-./build-image.sh -i /path/to/image.bin <build flags go here>
+./build-image.sh -i /path/to/image.bin <flags>
 ```
 The builder also has a few other flags, which can be seen by running the script with no arguments or passing `--help`, some of which are listed here.
 * `-k`, `--kernver` (hex int, 0 to ff)

--- a/docs/device-policy-editor.md
+++ b/docs/device-policy-editor.md
@@ -2,7 +2,7 @@
 Policies are signed by a private key, and the corresponding public key is used to verify them. For testing new policies, Google created the flag `--disable-policy-key-verification` (which modmium automatically places into /etc/chrome_dev.conf). With this, we can dump the device policy to a JSON file, edit it, and use the modified JSON to create a new device policy file with new values.
 
 ## Device policy editor instructions
-0. Enroll (device policies have to exist to be edited, after all)
+0. Enroll to automatically create the device policies.
 1. Open MOSH (see [./usage.md](usage.md) if you don't know how)
 2. Find the policy you wish to edit (see the Google [policy list](https://chromeenterprise.google/policies) to search for policy names)
 > [!NOTE]
@@ -11,12 +11,12 @@ Policies are signed by a private key, and the corresponding public key is used t
 > [!Caution]
 > If you modify *any* device policies, it'll stop sending new reports to the GAC and appear as offline. 
 > Use `Reset All Changes` to send reports to the GAC again.
-* For most users, relevant ones are:
-    * Restrictions/DeviceAllowNewUsers (if true, will allow any Google account to sign in)
-    * Restrictions/DeviceUnaffiliatedCrostiniAllowed (enabling the linux container)
-    * Restrictions/DeviceUserAllowlist (can be used to be more specific than DeviceAllowNewUsers, (for example specifying a specific account instead of using a wildcard) for most people, adding `"*@gmail.com",` is good enough)
-    * Restrictions/DeviceBorealisAllowed (enabling steam, also needs to be turned on in chrome://flags)
-    * Restrictions/VirtualMachinesAllowed (required for Borealis and Crostini)
-    * Restrictions/UnaffiliatedArcAllowed (enabling play store)
-    * Enterprise Settings/DeviceOpenNetworkConfiguration (may contain `"DisableNetworkTypes": [ "VPN" ]`, remove if you want to use a VPN)
-* When done editing, either press **[Ctrl+C]** to return to MOSH without applying policies (but saving the configuration in the JSON file) or `Apply Policies` to apply your changes
+* For most users, the relevant policies are:
+    * Restrictions/DeviceAllowNewUsers (Allows you to add new accounts when toggled on)
+    * Restrictions/DeviceUnaffiliatedCrostiniAllowed (Enables Crostini, the Linux container/VM)
+    * Restrictions/DeviceUserAllowlist (More specific than DeviceAllowNewUsers, such as allowing a specific user account without the wildcard. For most people, adding `"*@gmail.com",` is good enough)
+    * Restrictions/DeviceBorealisAllowed (Enables the Steam for Chromebook beta, also needs to be turned on in `chrome://flags`)
+    * Restrictions/VirtualMachinesAllowed (REQUIRED for Borealis/Crostini)
+    * Restrictions/UnaffiliatedArcAllowed (Enable Play store, it DOES function if you set user policies, this reduces jank/odds of it breaking)
+    * Enterprise Settings/DeviceOpenNetworkConfiguration (May contain `"DisableNetworkTypes": [ "VPN" ]` and/or `[ "Cellular" ]`  modify to be blank `"DisableNetworkTypes": []` if you want to use VPN/Mobile data)
+* When done editing, either press **[Ctrl+C]** to return to MOSH, then you can press `Apply Policies` to apply your changes!

--- a/docs/device-policy-editor.md
+++ b/docs/device-policy-editor.md
@@ -2,7 +2,7 @@
 Policies are signed by a private key, and the corresponding public key is used to verify them. For testing new policies, Google created the flag `--disable-policy-key-verification` (which modmium automatically places into /etc/chrome_dev.conf). With this, we can dump the device policy to a JSON file, edit it, and use the modified JSON to create a new device policy file with new values.
 
 ## Device policy editor instructions
-0. Enroll to automatically create the device policies.
+0. Enroll (creates the initial device policies)
 1. Open MOSH (see [./usage.md](usage.md) if you don't know how)
 2. Find the policy you wish to edit (see the Google [policy list](https://chromeenterprise.google/policies) to search for policy names)
 > [!NOTE]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,7 @@
   * +: Once the image is created, no internet connection is required to install
   * +: Can prepare bootsplashes and policy.json
   * +: Allows custom modifications to Modmium
-  * -: Requires a linux environment to build (you can use WSL if you're building on Windows)
+  * -: Requires a linux environment to build (you can use WSL if you're building on Windows. the dependencies will be the same as Ubuntu)
   * -: More complicated to install
 
 ## VT2 Installation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,7 @@
   * +: Once the image is created, no internet connection is required to install
   * +: Can prepare bootsplashes and policy.json
   * +: Allows custom modifications to Modmium
-  * -: Requires a linux environment to build, this can include WSL if you're using Windows
+  * -: Requires a linux environment to build (you can use WSL if you're building on Windows)
   * -: More complicated to install
 
 ## VT2 Installation
@@ -50,4 +50,4 @@ Of note, __before__ flashing the image FWMP must be disabled. To be sure it is, 
 ## Flags (ADVANCED USERS ONLY)
 * `modmium.sh` flags:
   * `-u`/`--userkeys`: If you have a USB drive with your own signing keys on them, you can use it. Be sure to plug it into the chromebook before running `modmium.sh`; yes, even the second time (`-b` will be ignored if you pass `-u`.)
-  * `-b`/`--backup`: default true, whether or not to create a firmware backup. pass `--nobackup` if you are absolutely certain you don't need one (Strongly advise you **don't** do this, but if you know what you're doing, we can't stop you).
+  * `-b`/`--backup`: default true, whether or not to create a firmware backup. pass `--nobackup` if you are absolutely certain you don't need one (We recommend you **don't** do this, but if you know what you're doing, we can't stop you).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@
 
 ## Pros and Cons
 * VT2 Installation:
-  * +: Doesn't require a linux machine to build
+  * +: Doesn't require a linux environment to build
   * +: More convenient to install
   * -: Requires internet connection every time you install
   * -: Doesn't come with bootsplashes or policy.json pre-installed
@@ -14,10 +14,14 @@
   * +: Once the image is created, no internet connection is required to install
   * +: Can prepare bootsplashes and policy.json
   * +: Allows custom modifications to Modmium
-  * -: Requires a linux machine to build
+  * -: Requires a linux environment to build, this can include WSL if you're using Windows
   * -: More complicated to install
 
 ## VT2 Installation
+> [!NOTE]
+> *F2 is usually the key ***to the right of*** the (←)Backwards/Left arrow key, usually being either (→)Forwards/Right arrow or (↻)Refresh key.
+>
+> *This varies across devices.*
 1. Boot [developer mode](https://docs.crosbreaker.com/quickstart/exploits/misc/developer-mode/).
 2. Connect to the internet by pressing the wifi icon in the bottom right (don't press "Get Started").
 3. Open VT2 **[Ctrl+Alt+F2]** and login as `root` then run `cd /usr/local; curl -LOsk modmium.dev/modmium.sh && bash modmium.sh <flags>`
@@ -45,5 +49,5 @@ Of note, __before__ flashing the image FWMP must be disabled. To be sure it is, 
 
 ## Flags (ADVANCED USERS ONLY)
 * `modmium.sh` flags:
-  * `-u`/`--userkeys`: if you have a usb drive with your own signing keys on them, you can use it. be sure to plug it into the chromebook before running `modmium.sh`; yes, even the second time (`-b` will be ignored if you pass `-u`)
-  * `-b`/`--backup`: default true, whether or not to create a firmware backup. pass `--nobackup` if you are absolutely certain you don't need one (strongly advise you don't do this, but if you know what you're doing, we can't stop you).
+  * `-u`/`--userkeys`: If you have a USB drive with your own signing keys on them, you can use it. Be sure to plug it into the chromebook before running `modmium.sh`; yes, even the second time (`-b` will be ignored if you pass `-u`.)
+  * `-b`/`--backup`: default true, whether or not to create a firmware backup. pass `--nobackup` if you are absolutely certain you don't need one (Strongly advise you **don't** do this, but if you know what you're doing, we can't stop you).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -21,13 +21,15 @@ MOSH is a terminal UI (TUI) very similar to [Cr3nroll](https://github.com/crosmi
 <br>
 
 ## VT-MOSH
+> [!NOTE]
+> *F2 is usually the key ***to the right of*** the (←)Backwards/Left arrow key, usually being either (→)Forwards/Right arrow or (↻)Refresh key.
+>
+> *This varies across devices.*
+
 To open VT-MOSH via VT-2, press **[Ctrl+Alt+F2]**\* on any menu and login as `root` or `chronos`.<br>
 VT-MOSH is a terminal UI (TUI) nearly identical to regular MOSH.
 * Navigation is done with arrow or number keys
 * To return from a submenu to the main menu, either use the given `Exit` button or press **[Ctrl+C]**<br>
-
--- VT-MOSH does not have tabs --<br>
-\**(F2 is often the forward arrow, but it may vary by device)*<br>
 
 > [!tip]
 > You can put a password on MOSH, VT-MOSH, and all VT(s) by running the command `chromeos-setdevpasswd` as `root`.

--- a/docs/user-policy-editor.md
+++ b/docs/user-policy-editor.md
@@ -8,7 +8,7 @@ You'll want to do this if you want your enterprise's extensions to install, for 
 1. Install and boot modmium in verified (see [./installation.md](./installation.md).)
 2. (Optional) Obtain your enterprise's policy file (see [obtaining your policy file after install](#obtaining-your-policy-file-after-install))
   - This is not required if you did the pre-install step, or don't want any enterprise settings on your user account.
-3. Open VT2 once __fully enrolled__, DO NOT SIGN IN YET.
+3. Open VT2 once you've finished enrollment, a good place to enter is the "Enrollment is complete." screen. __DO NOT SIGN IN. IF YOU DID AND WANT TO EDIT USER POLICIES, POWERWASH AND TRY AGAIN.__
 4. Navigate to `Edit User Policies`.
 5. Select `Run Policy Editor` and enter your enterprise email when prompted.
 6. When the fake device management server starts, go **back** to VT1 and **sign in with the same email**.

--- a/docs/vboot-utils.md
+++ b/docs/vboot-utils.md
@@ -2,8 +2,10 @@
 * Your distro doesn't provide vboot-utils
 * Your distro's package is super outdated 
 In these cases, you are able to compile it from source (though running tests will fail unless you satisfy all dependencies, this script only really relies on futility and vbutil_kernel, both of which do not interact with chromeos-flashrom or coreboot).
+* You could be using WSL to build and got a "manual intervention" error trying to install it automatically.
 ## Building
-(Note, this assumes you have the standard toolchain; git, a compiler, etc..)
+> [!NOTE]
+> This assumes you have the standard toolchain; git, a compiler, etc..
 ```bash
 git clone https://chromium.googlesource.com/chromiumos/platform/vboot_reference --depth 1 # depth 1 to save time
 cd vboot_reference


### PR DESCRIPTION
small changes, such as
* mentioning wsl as an option to build on windows
* also mention enterprises that block mobile data
* small mention of user policy play store in device policy doc
* actually say what the vt2 keys are for 99% of boards besides just 'it varies', correct me if im wrong but im not sure if theres chromebooks that have neither.
* making sure skids see steps better
* yell at them for missing said steps 
* grammarly is free!!!!!