### PR TITLE
Add --preinstall flag to cache dependencies across powerwashes

### DIFF
--- a/mod-files/usr/lib/libmosh.sh
+++ b/mod-files/usr/lib/libmosh.sh
@@ -28,6 +28,24 @@ UN=$'\033[4m' #underline
 RUN=$'\033[24m' #reset underline
 MILESTONE=$(grep MILESTONE /etc/lsb-release | cut -d= -f2 | tr -d '\r')
 
+# -- Preinstalled dependency cache (see the installer's --preinstall flag) --
+# Dependencies normally live on the stateful partition and get wiped by a
+# powerwash. If the installer was run with --preinstall, a cache of them was
+# baked into the RootFS (which powerwashes don't touch), so restore from it
+# here instead of redownloading every time a script needs git/file/etc.
+DEPS_CACHE="/usr/share/modmium/deps-cache.tar.gz"
+DEVINSTALL_MARKER="/mnt/stateful_partition/.devinstall_complete"
+restore_deps_cache() {
+  if [[ -f $DEPS_CACHE && ! -f $DEVINSTALL_MARKER ]]; then
+    echo -e "${G}Restoring preinstalled dependencies from cache (this only happens after a powerwash)...${N}"
+    tar -xzf $DEPS_CACHE -C / || return 1
+    touch $DEVINSTALL_MARKER
+    ldconfig
+    [[ -d /usr/local/usr/share/git-core/templates ]] && cp -r /usr/local/usr/share/git-core/templates /usr/share/git-core
+  fi
+}
+restore_deps_cache
+
 # STOLEN CODE FROM BR0KER TO GET MILESTONE :3
 get_largest_cros_blockdev() {
   local largest size dev_name tmp_size remo

--- a/modmium.sh
+++ b/modmium.sh
@@ -13,6 +13,7 @@ default_backup=$FLAGS_TRUE
 [[ $QUICKINSTALL == $FLAGS_TRUE ]] && default_backup=$FLAGS_FALSE
 DEFINE_boolean userkeys "$FLAGS_FALSE" "Whether or not to use user-generated signing keys." "u"
 DEFINE_boolean backup "$default_backup" "Whether or not to backup firmware from flashing devkeys." "b"
+DEFINE_boolean preinstall "$FLAGS_FALSE" "Whether or not to preinstall all Modmium dependencies (git, file, and other tool deps used by VT-MOSH) so they're cached on the RootFS and persist across powerwashes." "p"
 FLAGS $@
 [[ $QUICKINSTALL == $FLAGS_TRUE ]] && export FLAG_userkeys=$FLAGS_FALSE
 
@@ -225,6 +226,12 @@ installCros() {
   cp build-utils/lib/minioverride-${arch}.so mnt/lib/minioverride.so
   rm -rf mnt/root/.force_update_firmware mnt/opt/google/cr50 mnt/opt/google/ti50
   [[ -d ${BACKUP}/userkeys ]] && cp -r ${BACKUP}/userkeys mnt/usr/share/vboot
+  if [[ $FLAGS_preinstall == $FLAGS_TRUE && -n $DEPSCACHE && -f $DEPSCACHE ]]; then
+    echo -e "${G}Embedding preinstalled dependencies into new RootFS...${N}"
+    mkdir -p mnt/usr/share/modmium
+    cp $DEPSCACHE mnt/usr/share/modmium/deps-cache.tar.gz
+    rm -f $DEPSCACHE
+  fi
   echo $branch > mnt/.branch
 
   echo -e "${G}Syncing filesystem (may take a while)...${N}"
@@ -391,6 +398,23 @@ selUserBackup(){
   fi
 }
 
+DEPSCACHE="" # populated by preinstallDeps() when --preinstall is used
+
+preinstallDeps(){
+  echo -e "${G}Preinstalling all Modmium dependencies so they survive future powerwashes...${N}"
+  source /etc/profile # required to get emerge working
+  if [[ ! -f /mnt/stateful_partition/.devinstall_complete ]]; then
+    printf 'y\n\nn' | dev_install --reinstall || fail "${R}Could not install dependencies. Connect to the internet first.${N}" keepflag
+    touch /mnt/stateful_partition/.devinstall_complete
+  fi
+  ldconfig # reload shared libraries to include python libs
+  emerge git file cryptography nano pyyaml protobuf-python || fail "${R}Could not install dependencies. Connect to the internet first.${N}" keepflag
+  cp -r /usr/local/usr/share/git-core/templates /usr/share/git-core # fix the warning about git templates being missing
+  echo -e "${G}Caching dependencies so VT-MOSH won't need to redownload them after a powerwash...${N}"
+  DEPSCACHE=/tmp/modmium-deps-cache.tar.gz
+  tar -czf $DEPSCACHE -C / usr/local || fail "${R}Failed to cache dependencies.${N}" keepflag
+}
+
 modmiumInstall(){
   if [[ $FLAGS_userkeys == $FLAGS_TRUE ]]; then
     BACKUP=/tmp/backupdir
@@ -411,7 +435,9 @@ modmiumInstall(){
   else
     keydir=/usr/share/vboot/devkeys
   fi
-  if ! which git &>/dev/null || ! which file &>/dev/null; then
+  if [[ $FLAGS_preinstall == $FLAGS_TRUE ]]; then
+    preinstallDeps
+  elif ! which git &>/dev/null || ! which file &>/dev/null; then
     echo -e "${R}Dependencies not installed, installing...${N}"
     source /etc/profile # required to get emerge working
     if [[ ! -f /mnt/stateful_partition/.devinstall_complete ]]; then


### PR DESCRIPTION
VT-MOSH's "Manage Modmium" flow (and a few other scripts) lazily dev_install/emerge git, file, etc. on first use, but that all lives on the stateful partition so every powerwash forces a redownload.

Adding --preinstall to modmium.sh now installs the full dependency set during the initial install and packs it into a tarball that gets baked into the new RootFS at /usr/share/modmium/deps-cache.tar.gz (RootFS survives powerwashes, unlike stateful). libmosh.sh, which every mosh script sources, transparently restores that cache to /usr/local and touches the .devinstall_complete marker whenever it's missing, so dependencies stay preinstalled indefinitely without any network access.