### PR TITLE
Fix undefined fail() call in localacc.sh

### DIFF
--- a/mod-files/usr/bin/localacc.sh
+++ b/mod-files/usr/bin/localacc.sh
@@ -3,6 +3,12 @@
 
 source /usr/lib/libmosh.sh
 
+fail(){
+  echo -e "$1"
+  sleep 3
+  exit 1
+}
+
 if ! which git &>/dev/null || ! which file &>/dev/null; then
   echo -e "${R}Dependencies not installed, installing...${N}"
   source /etc/profile # required to get emerge working in mosh


### PR DESCRIPTION
Finally didn't mess it up bro holy

localacc.sh calls fail() in its dependency-bootstrap block when dev_install fails, but unlike every other script with this same block (update-modmium.sh, emergency-revert.sh, devpolicy-editor.sh, mosh-upol.sh), it never defines fail() itself, and libmosh.sh doesn't either. On a fresh install with no internet, dev_install fails, the undefined fail call errors out instead of exiting, and execution falls through anyway, marking dependency setup as done even though it isn't.