### PR TITLE
Centralize UX/error-handling, fix bugs, add tests & CI

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,0 +1,57 @@
+name: Lint and test
+
+on:
+  push:
+    branches: [stable, nightly]
+  pull_request:
+
+jobs:
+  syntax-check:
+    name: bash -n syntax check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check every shell script parses
+        run: |
+          set -e
+          fail=0
+          # .sh files, plus the handful of extensionless scripts we know are bash.
+          mapfile -d '' files < <(find . -name "*.sh" -not -path "./.git/*" -print0)
+          files+=("mod-files/usr/bin/.mix")
+          for f in "${files[@]}"; do
+            [ -f "$f" ] || continue
+            if ! bash -n "$f"; then
+              echo "::error file=$f::Syntax error"
+              fail=1
+            fi
+          done
+          exit $fail
+
+  shellcheck:
+    name: shellcheck (informational)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run shellcheck
+        # This repo's shared shell "library" relies on cross-file globals and
+        # intentional unquoted word-splitting that shellcheck can't see across
+        # file boundaries (see .shellcheckrc), and a couple of unrelated
+        # scripts trip false positives (x86 assembly inside a heredoc, etc).
+        # Rather than block PRs on pre-existing noise, this job always
+        # succeeds - it's here so the findings are visible in the log for
+        # anyone who wants to skim them, not as a merge gate.
+        run: |
+          mapfile -d '' files < <(find . -name "*.sh" -not -path "./.git/*" -not -name "cr3nroll.sh" -print0)
+          shellcheck --shell=bash "${files[@]}" || true
+
+  tests:
+    name: bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+      - name: Run tests
+        run: bats test/

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,10 @@
+# Modmium's shared shell "library" (libmosh.sh) and the scripts that source
+# it rely on globals being set by whichever script calls a given function
+# (options, functions, menuText, intdis, num_options, ...), and on unquoted
+# $@ for intentional word-splitting in the menu dispatch system (as_system,
+# employ, selector). shellcheck analyzes one file at a time and can't see
+# across that sourcing boundary, so these three checks are close to 100%
+# false positives on this codebase and just bury real findings in noise.
+disable=SC2034
+disable=SC2154
+disable=SC2068

--- a/mod-files/usr/bin/devpolicy-editor.sh
+++ b/mod-files/usr/bin/devpolicy-editor.sh
@@ -3,14 +3,7 @@
 
 source /root/.bashrc # to get $EDITOR
 jsonFile="/usr/local/share/policy-test-tool/dump.json"
-DEVINSTALL_FILE="/mnt/stateful_partition/.devinstall_complete"
 DEVPOL_FILE="/mnt/stateful_partition/.devpol_setup"
-
-fail(){
-  echo -e "$1"
-  sleep 3
-  exit 1
-}
 
 stty -echo
 tput civis
@@ -22,16 +15,7 @@ if [[ ! -f $DEVPOL_FILE ]] || [[ ! -d /usr/local/share/policy-test-tool ]]; then
   mkdir -p /usr/local/share
   rm -rf /usr/local/share/policy-test-tool
 
-  source /etc/profile # emerge breaks without this
-  echo -e "${B}Installing required dependencies...${N}"
-
-  if [[ ! -f $DEVINSTALL_FILE ]]; then
-    printf 'y\n\nn' | dev_install --reinstall || fail "${R}Could not install dependencies. Connect to the internet first.${N}"
-    touch $DEVINSTALL_FILE
-  fi
-
-  ldconfig # emerge breaks without this too
-  emerge cryptography nano pyyaml protobuf-python
+  ensure_deps cryptography nano pyyaml protobuf-python
 
   cp -r /usr/share/.policy-test-tool /usr/local/share/policy-test-tool
   touch $DEVPOL_FILE
@@ -390,18 +374,26 @@ full_menu(){
         3) submenu "Misc Settings" "${MISC[@]}" ;;
         4)
           allowInput
-          echo -e "${G}Applying device policies!${N}"
-          python devpol.py $jsonFile && exit 0 || { sleep 2; disallowInput; } ;;
+          if confirm_destructive "This will apply your edited policies to this device's live configuration. Continue?"; then
+            echo -e "${G}Applying device policies!${N}"
+            python devpol.py $jsonFile && exit 0 || { sleep 2; disallowInput; }
+          else
+            disallowInput
+          fi ;;
         5)
           allowInput
-          echo -e "${Y}Reverting changes!${N}"
-          pushd /var/lib/devicesettings &> /dev/null
-          mv owner.key.bak.enterprise owner.key &> /dev/null
-          local policyBackup=$(ls policy.*.bak.enterprise 2>/dev/null)
-          [[ -n "$policyBackup" ]] && mv "$policyBackup" "${policyBackup%.bak.enterprise}" &> /dev/null
-          popd &> /dev/null
-          rm -rf $jsonFile
-          echo -e "${G}Done!${N}"; sleep 2; restart ui; exit 0 ;;
+          if confirm_destructive "This will discard every change you've made in this editor and restore the previous device policy. Continue?"; then
+            echo -e "${Y}Reverting changes!${N}"
+            pushd /var/lib/devicesettings &> /dev/null
+            mv owner.key.bak.enterprise owner.key &> /dev/null
+            local policyBackup=$(ls policy.*.bak.enterprise 2>/dev/null)
+            [[ -n "$policyBackup" ]] && mv "$policyBackup" "${policyBackup%.bak.enterprise}" &> /dev/null
+            popd &> /dev/null
+            rm -rf $jsonFile
+            echo -e "${G}Done!${N}"; sleep 2; restart ui; exit 0
+          else
+            disallowInput
+          fi ;;
         6)
           exit 0 ;;
       esac

--- a/mod-files/usr/bin/emergency-revert.sh
+++ b/mod-files/usr/bin/emergency-revert.sh
@@ -27,15 +27,7 @@ fail(){
 }
 
 if ! which git &>/dev/null || ! which file &>/dev/null; then
-  echo -e "${R}Dependencies not installed, installing...${N}"
-  source /etc/profile # required to get emerge working in mosh
-  if [[ ! -f /mnt/stateful_partition/.devinstall_complete ]]; then
-    printf 'y\n\nn' | dev_install --reinstall || fail "${R}Could not install dependencies. Connect to the internet first.${N}"
-    touch /mnt/stateful_partition/.devinstall_complete
-  fi
-  ldconfig # reload shared libraries to include python libs
-  emerge git file protobuf-python
-  cp -r /usr/local/usr/share/git-core/templates /usr/share/git-core # fix the warning about git templates being missing
+  ensure_deps git file protobuf-python
 fi
 
 checkWP(){
@@ -55,10 +47,7 @@ checkWP(){
 
 unkeyroll(){
   futility gbb -s --flash --recoverykey="/root/.recoverykeys/$board.vbpubk"
-  echo -e "Would you like to be unkeyrolled permanently? [y/N]"
-  echo -e "${R}This will prevent you from reflashing devkeys until you re-disable FWWP fully${N}"
-  read -re
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
+  if confirm_destructive "Would you like to be unkeyrolled permanently? This will prevent you from reflashing devkeys until you re-disable FWWP fully."; then
     flashrom --wp-range 0,0 || flashrom --wp-range 0 0
     flashrom --wp-enable
   fi
@@ -68,9 +57,7 @@ revertMPkeys(){
   clear
   stty echo
   checkWP
-  echo -e "${R}This will update your firmware and revert your chromebook to stock keys (undoing developer firmware changes), are you ${UN}sure${RUN} you want to continue?${N} [y/N]"
-  read -re
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
+  if confirm_irreversible "This will update your firmware and revert your chromebook to stock keys (undoing developer firmware changes). This cannot be undone without redoing the DevFW flash. Are you sure you want to continue?"; then
     echo -e "Restoring MPkeys, ${G}please connect your device to power (if you haven't already)${N}"
     sleep 2
     echo "Modmium stock firmware restore script by codenerd87"
@@ -105,11 +92,7 @@ revertMPkeys(){
     echo "Firmware flashed successfully!"
 
     if [[ $board =~ ^corsola|^dedede|^nissa ]]; then
-      echo -e "${B}Do you want to unkeyroll? [y/N]"
-      read -re
-      if [[ $REPLY =~ ^[Yy]$ ]]; then
-        unkeyroll
-      fi
+      confirm_destructive "Do you want to unkeyroll?" && unkeyroll
     fi
     echo -e "Your device is now on MPkeys! Modmium will not boot after your device reboots, please make sure you restore factory ChromeOS or use a recovery image!"
     sleep 3
@@ -118,48 +101,6 @@ revertMPkeys(){
     fail "Exiting..."
   fi
   fail "Exiting..."
-}
-
-BOARD="$(grep '^CHROMEOS_RELEASE_DESCRIPTION=' /etc/lsb-release | awk '{print $NF}')"
-getImageLink(){
-  jsonLink="https://cdn.jsdelivr.net/gh/crosbreaker/chromeos-releases-data/data.json"
-  echo -e "${G}Checking crosbreaker/chromeos-releases-data for recovery image URL...${N}"
-  recoveryUrl=$(curl -sL $jsonLink | jq -r --arg board $BOARD --arg ver $VERSION '
-    .[$board].images // []
-    | map(select(
-    .channel == "stable-channel" and
-    (.chrome_version | startswith($ver + "."))
-    ))
-    | sort_by(.last_modified)
-    | last
-    | .url // empty
-    ')
-  if [[ -n $recoveryUrl && $recoveryUrl =~ dl\.google\.com ]]; then
-    echo -e "${G}Recovery URL found!${N}"
-    sleep 1
-  else
-    fail "${R}Recovery URL not found or invalid :(${N}"
-  fi
-}
-
-get_booted_kernnum() {
-  if (( $(cgpt show -n "$intdis" -i 2 -P) > $(cgpt show -n "$intdis" -i 4 -P) )); then
-    echo -n 2
-  else
-    echo -n 4
-  fi
-}
-get_booted_rootnum() {
-  echo $(( $(get_booted_kernnum) + 1 ))
-}
-opposite_num() {
-  case $1 in
-    2) echo -n 4 ;;
-    3) echo -n 5 ;;
-    4) echo -n 2 ;;
-    5) echo -n 3 ;;
-    *) echo -n "skid" ;;
-  esac
 }
 
 installCros() {
@@ -187,6 +128,8 @@ installCros() {
   echo -ne "Version of ChromeOS you want to install: "
   read -rep "" VERSION
   [[ $VERSION =~ ^[0-9]+$ ]] || fail "${R}Version must be numeric, exiting...${N}"
+  confirm_irreversible "This will overwrite the inactive partition with ChromeOS $VERSION. This cannot be undone once it starts." \
+    || fail "Exiting..."
   getImageLink
   intdis=$(rootdev -d)
   if echo "$intdis" | grep -q '[0-9]$'; then
@@ -242,4 +185,3 @@ menu_reset
 clear
 full_menu
 tput cnorm
-selector

--- a/mod-files/usr/bin/features.sh
+++ b/mod-files/usr/bin/features.sh
@@ -38,6 +38,7 @@ checkStatus() {
 
 chromebookPlus(){
   if [[ $chromebookplus == 0 ]]; then
+  confirm_destructive "This forces Chromebook Plus feature management on, which can behave unpredictably on unsupported hardware. Continue?" || { menu_reset; full_menu; return; }
   echo -e "Enabling Chromebook Plus features..."
   echo -e "Credits to Pilot Bell for making this toggle"
   sleep 1
@@ -50,6 +51,7 @@ chromebookPlus(){
 }
 studioMic(){
   if [[ $studiomic == 0 ]]; then
+    confirm_destructive "This temporarily spoofs your board identity to install cross-board packages, and can leave your system in a broken state if interrupted. Continue?" || { menu_reset; full_menu; return; }
     echo -e "Enabling Studio Mic..."
     echo -e "Credits to shadowed1 and Pilot Bell for making this toggle"
     sleep 1
@@ -597,4 +599,3 @@ menu_reset
 clear
 full_menu
 tput cnorm
-selector

--- a/mod-files/usr/bin/localacc.sh
+++ b/mod-files/usr/bin/localacc.sh
@@ -3,22 +3,8 @@
 
 source /usr/lib/libmosh.sh
 
-fail(){
-  echo -e "$1"
-  sleep 3
-  exit 1
-}
-
 if ! which git &>/dev/null || ! which file &>/dev/null; then
-  echo -e "${R}Dependencies not installed, installing...${N}"
-  source /etc/profile # required to get emerge working in mosh
-  if [[ ! -f /mnt/stateful_partition/.devinstall_complete ]]; then
-    printf 'y\n\nn' | dev_install --reinstall || fail "${R}Could not install dependencies. Connect to the internet first.${N}"
-    touch /mnt/stateful_partition/.devinstall_complete
-  fi
-  ldconfig # reload shared libraries to include python libs
-  emerge git file
-  cp -r /usr/local/usr/share/git-core/templates /usr/share/git-core # fix the warning about git templates being missing
+  ensure_deps git file
 fi
 export PATH="/usr/local/bin:/usr/local/sbin:/usr/local/usr/bin:/usr/local/usr/sbin:/usr/bin:/usr/sbin:/bin:/sbin:$PATH"
 ldconfig

--- a/mod-files/usr/bin/localacc.sh
+++ b/mod-files/usr/bin/localacc.sh
@@ -3,6 +3,12 @@
 
 source /usr/lib/libmosh.sh
 
+fail(){
+  echo -e "$1"
+  sleep 3
+  exit 1
+}
+
 if ! which git &>/dev/null || ! which file &>/dev/null; then
   echo -e "${R}Dependencies not installed, installing...${N}"
   source /etc/profile # required to get emerge working in mosh

--- a/mod-files/usr/bin/modify-bootsplash.sh
+++ b/mod-files/usr/bin/modify-bootsplash.sh
@@ -121,10 +121,7 @@ download_backup() {
 }
 
 remove() {
-  echo -e "${Y}This will remove the bootsplash ENTIRELY. Use restore to fix it.${N}"
-  read -p "Contnue? (y/N) " -n 1 -r
-  echo
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
+  if confirm_destructive "This will remove the bootsplash ENTIRELY. Use restore to fix it. Continue?"; then
     echo -e "${Y}Removing bootsplash...${N}"
     for assets in cros_assets cros_assets_2; do
       for file in $(find ${!assets} -name 'boot_splash_frame*.png'); do
@@ -161,4 +158,3 @@ menu_reset
 clear
 full_menu
 tput cnorm
-selector

--- a/mod-files/usr/bin/mosh-apps.sh
+++ b/mod-files/usr/bin/mosh-apps.sh
@@ -23,14 +23,14 @@ index() {
     name=$(echo "$name" | xargs)
     [[ -z "$path" ]] && continue
     paths+=("$path")
-    display_num=$(( ${#paths[@]} ))
-    options+=("$display_num) $name")
+    options+=("$name")
   done < /usr/local/config/apps.conf
 
   num_options=${#options[@]}
   selected_index=0
+  menuText=""
   if [[ " ${options[*]} " == *" Edit apps.conf "* ]]; then
-    nopt=1
+    menuText="\nINFO: You can add up to 9 apps (or scripts) to this menu by editing '/usr/local/config/apps.conf'\n(The formatting is 'COMMAND | NAME' on each line)"
   fi
   if [[ $num_options -gt 9 ]]; then
     clear
@@ -45,6 +45,12 @@ EOF
   fi
 }
 
+# menu_reset is the standard libmosh entry point (called by full_menu when it
+# needs to redraw), so define it in terms of index() instead of duplicating
+# libmosh's own full_menu/display_menu here.
+menu_reset() {
+  index
+}
 
 selector() {
   torun="${paths[$selected_index]}"
@@ -63,62 +69,7 @@ selector() {
   esac
 }
 
-full_menu() {
-  clear
-  stty -echo
-  tput civis
-  while true; do
-    display_menu
-    read -rsn1 key
-    if [[ "$key" == $'\x1b' ]]; then
-      read -rsn2 -t 1 keyseq
-      case "$keyseq" in
-        '[A')
-          selected_index=$(((selected_index - 1 + num_options) % num_options))
-          ;;
-        '[B')
-          selected_index=$(((selected_index + 1) % num_options))
-          ;;
-      esac
-    elif [[ "$key" =~ [1-9] ]]; then
-      target_index=$((key - 1))
-      if [ "$target_index" -lt "$num_options" ]; then
-        selected_index=$target_index
-      fi
-    elif [[ "$key" == "" ]]; then
-      break
-    fi
-    tput rc
-  done
-  selector
-}
-display_menu() {
-  tput sc
-  menu_logo
-
-  if [[ "$MILESTONE" == "" ]]; then
-    echo -e "${R}Uhh... how are you seeing this if ChromeOS isn't installed..?${N}"
-  elif [[ "$MILESTONE" -le 131 ]]; then
-    echo -e "(WARNING): you are currently on ChromeOS ${R}v$MILESTONE${N}, which is not officially supported by Modmium."
-  elif [[ "$STABLEVERSIONS" =~ (^|,)"$MILESTONE"(,|$) ]]; then
-    echo -e "-- You are currently on ChromeOS ${G}v$MILESTONE${N} (Modmium ${modver} ${branch}) --"
-  else
-    echo -e "-- You are currently on ChromeOS ${R}v$MILESTONE${N} (Modmium ${modver} ${branch}) -- [This version hasn't been tested by the Modmium devs, but it will likely still work fine.]"
-  fi
-  if [[ $nopt == 1 ]];then
-    echo -e "\nINFO: You can add up to 9 apps (or scripts) to this menu by editing '/usr/local/config/apps.conf'\n(The formatting is 'COMMAND | NAME' on each line)"
-  fi
-  echo ""
-  for i in "${!options[@]}"; do
-    if [[ $i -eq $selected_index ]]; then
-      printf "\e[7m > ${options[$i]} \e[0m\n"
-    else
-      printf "   ${options[$i]}      \n"
-    fi
-  done
-}
 clear
-index
+menu_reset
 full_menu
 tput cnorm
-selector

--- a/mod-files/usr/bin/mosh-doctor.sh
+++ b/mod-files/usr/bin/mosh-doctor.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# written by Claude (self-check / doctor script)
+# Runs a handful of read-only sanity checks and reports them in plain
+# language, so a user can self-diagnose before asking for support.
+
+source /usr/lib/libmosh.sh
+
+PASS="${G}[ OK ]${N}"
+WARN="${Y}[WARN]${N}"
+FAIL="${R}[FAIL]${N}"
+
+report() {
+  # report <PASS|WARN|FAIL var> <message>
+  echo -e "$1 $2"
+}
+
+clear
+echo -e "${B}Modmium Health Check${N}"
+echo -e "${D}Read-only checks, nothing here will change anything on your device.${N}\n"
+
+# -- RootFS filesystem --
+fstype=$(findmnt -no FSTYPE / 2>/dev/null)
+if [[ "$fstype" == "ext4" ]]; then
+  report "$PASS" "RootFS is ext4."
+elif [[ "$fstype" == "ext2" ]]; then
+  report "$WARN" "RootFS is still ext2 - it'll be upgraded to ext4 next time you change ChromeOS version."
+else
+  report "$FAIL" "Could not determine RootFS filesystem type (got '$fstype')."
+fi
+
+# -- Modmium identity files --
+if [[ -f /usr/share/.version && -f /.branch ]]; then
+  report "$PASS" "Modmium $(cat /usr/share/.version 2>/dev/null) ($(cat /.branch 2>/dev/null)) identity files present."
+else
+  report "$FAIL" "Missing /usr/share/.version or /.branch - this doesn't look like a normal Modmium install."
+fi
+
+# -- Dependency marker consistency --
+if [[ -f $DEVINSTALL_MARKER ]]; then
+  if which git &>/dev/null && which file &>/dev/null; then
+    report "$PASS" "Dev packages marker present and git/file are actually installed."
+  else
+    report "$WARN" "Dev packages marker exists but git/file aren't on PATH. Run 'rm $DEVINSTALL_MARKER' then reopen a menu that needs them to force a clean reinstall."
+  fi
+else
+  report "$WARN" "Dev packages haven't been installed yet on this boot of stateful (normal right after a powerwash) - they'll be installed automatically the next time something needs them."
+fi
+
+# -- Stateful free space --
+freeKB=$(df /mnt/stateful_partition 2>/dev/null | awk 'NR==2 {print $4}')
+if [[ -n $freeKB ]]; then
+  freeMB=$((freeKB / 1024))
+  if [[ $freeMB -lt 512 ]]; then
+    report "$FAIL" "Only ${freeMB}MB free on stateful - installs and updates will likely fail. Free up space (Downloads, apps, etc)."
+  elif [[ $freeMB -lt 2048 ]]; then
+    report "$WARN" "Only ${freeMB}MB free on stateful - that's cutting it close for a ChromeOS reinstall."
+  else
+    report "$PASS" "${freeMB}MB free on stateful."
+  fi
+else
+  report "$FAIL" "Could not read free space on stateful."
+fi
+
+# -- Internet connectivity --
+if curl -fsSL --max-time 5 -o /dev/null "https://cdn.jsdelivr.net"; then
+  report "$PASS" "Internet connectivity looks fine."
+else
+  report "$WARN" "Couldn't reach the internet just now - dependency installs, ChromeOS version changes, and updates all need it."
+fi
+
+# -- Firmware write protection / DevFW status --
+writeprotect=$(flashrom --wp-status 2>&1 | grep "disabled")
+if [[ -n $writeprotect ]]; then
+  report "$PASS" "Firmware write protection is disabled."
+else
+  report "$WARN" "Firmware write protection is currently enabled - some menu options (enrollment, firmware tools) need it off."
+fi
+
+devfw=$(vpd -i RO_VPD -g "dev_firmware" 2>/dev/null)
+if [[ "$devfw" == "1" ]]; then
+  report "$PASS" "DevFW flag is set."
+else
+  report "$WARN" "DevFW flag is not set (unexpected if Modmium is fully installed and working)."
+fi
+
+# -- Recent failures in the shared Modmium log --
+if [[ -f $MODMIUM_LOG ]]; then
+  recentFails=$(grep "FAILED" "$MODMIUM_LOG" 2>/dev/null | tail -5)
+  if [[ -n $recentFails ]]; then
+    echo -e "\n${Y}Most recent failures logged (see $MODMIUM_LOG for the full history):${N}"
+    echo "$recentFails"
+  else
+    report "$PASS" "No failures recorded in the Modmium log."
+  fi
+else
+  echo -e "\n${D}No Modmium log yet at $MODMIUM_LOG - nothing has logged an action or failure since the last powerwash.${N}"
+fi
+
+echo ""
+log_action "Ran health check"
+read -n1 -rsp "Press any key to return to the menu..."

--- a/mod-files/usr/bin/mosh-misc.sh
+++ b/mod-files/usr/bin/mosh-misc.sh
@@ -64,4 +64,3 @@ menu_reset
 clear
 full_menu
 tput cnorm
-selector

--- a/mod-files/usr/bin/mosh-misc.sh
+++ b/mod-files/usr/bin/mosh-misc.sh
@@ -28,7 +28,7 @@ ${Y}lxrd: Discovered policy-test-tool and created device policy editing script, 
 \033[38;5;94mcon: emotional support (also helped with minor bugs in image downloader)${N}
 \033[38;5;51mCasper1051, \033[38;5;93mMoonstone, \033[38;5;57mpilgorr${N}: creating the default bootsplashes.
 \033[38;5;201mpers5124, \033[38;5;214mdinonuget_, \033[38;5;49mspacenerd1235, \033[38;5;118mxmb9${N}: private beta testers, found and reported lots of bugs.
-\033[38;5;208mTullysaurus: Fixed the undefined fail() call in localacc.sh, and added centralized confirmations/logging/error-handling and a test suite.${N}
+\033[38;5;208mTullysaurus: Added centralized confirmations, logging, error-handling, and a test suite.${N}
 
 ${D}[ Removing this menu from Modmium is not permitted ]${N}
 -- Press any key to return --

--- a/mod-files/usr/bin/mosh-misc.sh
+++ b/mod-files/usr/bin/mosh-misc.sh
@@ -28,6 +28,7 @@ ${Y}lxrd: Discovered policy-test-tool and created device policy editing script, 
 \033[38;5;94mcon: emotional support (also helped with minor bugs in image downloader)${N}
 \033[38;5;51mCasper1051, \033[38;5;93mMoonstone, \033[38;5;57mpilgorr${N}: creating the default bootsplashes.
 \033[38;5;201mpers5124, \033[38;5;214mdinonuget_, \033[38;5;49mspacenerd1235, \033[38;5;118mxmb9${N}: private beta testers, found and reported lots of bugs.
+\033[38;5;208mTullysaurus: Fixed the undefined fail() call in localacc.sh, and added centralized confirmations/logging/error-handling and a test suite.${N}
 
 ${D}[ Removing this menu from Modmium is not permitted ]${N}
 -- Press any key to return --
@@ -51,12 +52,15 @@ prenix(){
 credits(){
   runscriptnoroot creditsMenu
 }
+doctor(){
+  runscript /usr/bin/mosh-doctor.sh
+}
 # -- MAIN SCRIPT --
 tput civis # :whale:
 
 menu_reset() {
-  options=("Modify Bootsplash" "Open Cr3nroll" "${R}Emergency Revert${N}" "Install Nix" "Credits" "Go back")
-  functions=("modsplash"  "cr3nroll" "erevert" "prenix" "credits" "quit")
+  options=("Modify Bootsplash" "Open Cr3nroll" "${R}Emergency Revert${N}" "Install Nix" "Health Check" "Credits" "Go back")
+  functions=("modsplash"  "cr3nroll" "erevert" "prenix" "doctor" "credits" "quit")
   num_options=${#options[@]}
 }
 

--- a/mod-files/usr/bin/mosh-upol.sh
+++ b/mod-files/usr/bin/mosh-upol.sh
@@ -7,23 +7,21 @@ source /usr/lib/libmosh.sh
 source /etc/profile
 
 # -- policy flags --
-DEVINSTALL_FILE="/mnt/stateful_partition/.devinstall_complete"
 POLTEST_FILE="/mnt/stateful_partition/.policytesttool_setup"
 POLICYFILE="/root/policy.json"
 
 # -- FUNCTIONS --
 
-fail(){
-  echo -e "$1"
-  sleep 3
-  exit 1
-}
-
 reinstall(){
-  rm -f "$DEVINSTALL_FILE" "$POLTEST_FILE"
-  echo -e "${G}Removed .devinstall_complete and .policytesttool_setup markers.${N}"
-  sleep 2
-  exit
+  if confirm_destructive "This will clear the policy test tool's setup markers, so the next run reinstalls everything from scratch. Continue?"; then
+    rm -f "$DEVINSTALL_MARKER" "$POLTEST_FILE"
+    echo -e "${G}Removed .devinstall_complete and .policytesttool_setup markers.${N}"
+    sleep 2
+    exit
+  else
+    menu_reset
+    full_menu
+  fi
 }
 
 install(){
@@ -40,13 +38,7 @@ install(){
     exit 0
   fi
 
-  if [[ ! -f $DEVINSTALL_FILE ]]; then
-    echo -e "${G}Installing required dependencies...${N}"
-    printf 'y\n\nn' | dev_install --reinstall || fail "${R}Could not install dependencies. Connect to the internet first.${N}"
-    ldconfig
-    emerge protobuf-python
-    touch $DEVINSTALL_FILE
-  fi
+  ensure_deps protobuf-python
 
   cp /etc/chrome_dev.conf /etc/.chrome_dev.conf
 
@@ -231,7 +223,7 @@ menu_logo() {
 
 menu_reset() {
   menuText="\nPolicy Test Tool [User Policy Editor]\n${D}[Please note that this will set your policies to the recommended defaults for Modmium,\nif you'd like to edit them, they can be found in '${N}/usr/local/share/policy-test-tool/policies.json${D}']${N}\n"
-  if [[ -f $DEVINSTALL_FILE || -f $POLTEST_FILE ]]; then
+  if [[ -f $DEVINSTALL_MARKER || -f $POLTEST_FILE ]]; then
     options=("Run Policy Editor" "Update policy.json [from downloads]" "Reinstall" "Exit")
     functions=("install" "grabpolicy" "reinstall" "quit")
   else
@@ -250,4 +242,3 @@ menu_reset
 clear
 full_menu
 tput cnorm
-selector

--- a/mod-files/usr/bin/nix-preinstall.sh
+++ b/mod-files/usr/bin/nix-preinstall.sh
@@ -49,4 +49,3 @@ menu_reset
 clear
 full_menu
 tput cnorm
-selector

--- a/mod-files/usr/bin/toggle-enrollment.sh
+++ b/mod-files/usr/bin/toggle-enrollment.sh
@@ -21,9 +21,7 @@ fail() {
 }
 
 promptPowerwash(){
-  echo -e "${Y}Would you like to powerwash now? [y/N]${N}"
-  read -re
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
+  if confirm_destructive "Would you like to powerwash now?"; then
     echo "fast safe keepimg" > /mnt/stateful_partition/factory_install_reset
     echo -e "${G}Done! Rebooting...${N}"
     sleep 1
@@ -34,9 +32,7 @@ promptPowerwash(){
 }
 
 allowen(){
-  echo -e "${B}You currently have enrollment disabled, would you like to [${G}allow${B}] enrollment? [y/N]${N}"
-  read -re
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
+  if confirm_destructive "You currently have enrollment disabled, would you like to allow enrollment?"; then
     rm /.deprovision
     echo -e "${G}Done!${N}"
     promptPowerwash
@@ -44,11 +40,9 @@ allowen(){
     fail # :whale:
   fi
 }
-  
+
 preventen(){
-  echo -e "${B}You currently have enrollment enabled, would you like to [${R}prevent${B}] enrollment? [y/N]${N}"
-  read -re
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
+  if confirm_destructive "You currently have enrollment enabled, would you like to prevent enrollment?"; then
     echo $(grep MILESTONE /etc/lsb-release | sed 's|^.*=||g') >/.deprovision
     echo -e "${G}Done!${N}"
     promptPowerwash
@@ -85,4 +79,3 @@ menu_reset
 clear
 full_menu
 tput cnorm
-selector

--- a/mod-files/usr/bin/update-modmium.sh
+++ b/mod-files/usr/bin/update-modmium.sh
@@ -1,29 +1,21 @@
 #!/bin/bash
 # written by mariah carey and DMD
 
+# -- Pre TUI init --
+stty -echo
+source /usr/lib/libmosh.sh
+
 fail(){
-  start powerd &>/dev/null
   local ec=$?
+  start powerd &>/dev/null
   echo -e "$1"
   sleep 2
   [[ ! $ec -eq 0 ]] && exit $ec
   exit 1
 }
 
-# -- Pre TUI init --
-stty -echo
-source /usr/lib/libmosh.sh
-
 if ! which git &>/dev/null || ! which file &>/dev/null; then
-  echo -e "${R}Dependencies not installed, installing...${N}"
-  source /etc/profile # required to get emerge working in mosh
-  if [[ ! -f /mnt/stateful_partition/.devinstall_complete ]]; then
-    printf 'y\n\nn' | dev_install --reinstall || fail "${R}Could not install dependencies. Connect to the internet first.${N}"
-    touch /mnt/stateful_partition/.devinstall_complete
-  fi
-  ldconfig # reload shared libraries to include python libs
-  emerge git file
-  cp -r /usr/local/usr/share/git-core/templates /usr/share/git-core # fix the warning about git templates being missing
+  ensure_deps git file
 fi
 
 intdis=$(rootdev -d)
@@ -34,28 +26,6 @@ else
 fi
 
 # -- FUNCTIONS --
-BOARD="$(grep '^CHROMEOS_RELEASE_DESCRIPTION=' /etc/lsb-release | awk '{print $NF}')"
-getImageLink(){
-  jsonLink="https://cdn.jsdelivr.net/gh/crosbreaker/chromeos-releases-data/data.json"
-  echo -e "${G}Checking crosbreaker/chromeos-releases-data for recovery image URL...${N}"
-  recoveryUrl=$(curl -sL $jsonLink | jq -r --arg board $BOARD --arg ver $VERSION '
-    .[$board].images // []
-    | map(select(
-    .channel == "stable-channel" and
-    (.chrome_version | startswith($ver + "."))
-    ))
-    | sort_by(.last_modified)
-    | last
-    | .url // empty
-    ')
-  if [[ -n $recoveryUrl && $recoveryUrl =~ dl\.google\.com ]]; then
-    echo -e "${G}Recovery URL found!${N}"
-    sleep 1
-  else
-    fail "${R}Recovery URL not found or invalid :(${N}"
-  fi
-}
-
 askBranch(){
   branchfile="$(cat /.branch)"
   [[ $branchfile ]] || branchfile="stable"
@@ -108,9 +78,9 @@ updateModmium() {
   [[ -d modmium ]] && rm -rf modmium
   if [[ -d /root/.ssh ]]; then
     [[ ! -d /home/chronos/user/.ssh ]] && mkdir /home/chronos/user/.ssh
-    git clone --depth 1 -b $branch --single-branch git@github.com:crosmium/modmium.git || fail "${R}Failed to clone repository, exiting...${N}"
+    git clone --depth 1 -b $branch --single-branch $MODMIUM_REPO_SSH || fail "${R}Failed to clone repository, exiting...${N}"
   else
-    git clone --depth 1 -b $branch --single-branch https://github.com/crosmium/modmium.git || fail "${R}Failed to clone repository, exiting...${N}"
+    git clone --depth 1 -b $branch --single-branch $MODMIUM_REPO_HTTPS || fail "${R}Failed to clone repository, exiting...${N}"
   fi
   echo -e "${G}Successfully cloned repository!${N} Dropping new files..."
   dropModFiles || fail "${R}Failed to drop updated files, please make an issue report on https://github.com/crosmium/modmium with details of changes you made, if any...${N}"
@@ -134,40 +104,6 @@ updateModmium() {
   exit
 }
 
-convertToExt4(){
-  echo -e "${Y}Converting new RootFS to ext4...${N}"
-  installRoot=${intdis_prefix}$(opposite_num $(get_booted_rootnum))
-  tune2fs -O has_journal -J size=16 ${installRoot} || fail "${R}Conversion failed!${N}"
-  e2fsck -fDy ${installRoot} || fail "${R}Conversion failed!${N}"
-  tune2fs -O extents ${installRoot} || fail "${R}Conversion failed!${N}"
-  e2fsck -fDy ${installRoot} || fail "${R}Conversion failed!${N}"
-  resize2fs -b ${installRoot} || fail "${R}Conversion failed!${N}"
-  e2fsck -fDy ${installRoot} || fail "${R}Conversion failed!${N}"
-  tune2fs -O metadata_csum ${installRoot} || fail "${R}Conversion failed!${N}"
-  e2fsck -fDy ${installRoot} || fail "${R}Conversion failed!${N}"
-  echo -e "${G}Conversion succeeded!${N}"
-  sync;sync;sync # oh how i love you sync, hopefully what is above this will make us less reliant on your help <3
-}
-get_booted_kernnum() {
-  if (( $(cgpt show -n "$intdis" -i 2 -P) > $(cgpt show -n "$intdis" -i 4 -P) )); then
-    echo -n 2
-  else
-    echo -n 4
-  fi
-}
-get_booted_rootnum() {
-  echo $(( $(get_booted_kernnum) + 1 ))
-}
-opposite_num() {
-  case $1 in
-    2) echo -n 4 ;;
-    3) echo -n 5 ;;
-    4) echo -n 2 ;;
-    5) echo -n 3 ;;
-    *) echo -n "skid" ;;
-  esac
-}
-
 installCros() {
   stop powerd &>/dev/null
   ldconfig
@@ -177,26 +113,16 @@ installCros() {
   read -rep "" VERSION
   [[ $VERSION =~ ^[0-9]+$ ]] || fail "${R}Version must be numeric, exiting...${N}"
   if [[ $VERSION -lt $MILESTONE ]]; then
-    echo -e "${R}WARNING: YOU ARE DOWNGRADING CHROMEOS ($MILESTONE -> $VERSION), THIS MAY CAUSE PROBLEMS OR WIPE USER DATA.${N}\nDo not make an issue report if you run into problems."
-  echo -e "${B}Continue anyways? [y/N]${N}"
-  read -rep ""
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
-      echo -e "${B}Continuing...\n${N}"
-    else
-      fail "${R}Exiting...${N}"
-    fi
+    confirm_destructive "WARNING: YOU ARE DOWNGRADING CHROMEOS ($MILESTONE -> $VERSION), THIS MAY CAUSE PROBLEMS OR WIPE USER DATA.\nDo not make an issue report if you run into problems.\nContinue anyways?" \
+      || fail "${R}Exiting...${N}"
   fi
   if [[ $VERSION -lt 131 ]]; then
-    echo -e "${R}WARNING: VERSIONS BELOW 131 ARE NOT SUPPORTED.${N}\nDo not make an issue report if you run into problems."
-    echo -e "${B}Continue anyways? [y/N]${N}"
-    read -rep ""
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-      echo -e "${B}Continuing...${N}"
-    else
-      fail "${R}Exiting...${N}"
-    fi
+    confirm_destructive "WARNING: VERSIONS BELOW 131 ARE NOT SUPPORTED.\nDo not make an issue report if you run into problems.\nContinue anyways?" \
+      || fail "${R}Exiting...${N}"
   fi
   [[ ( $MILESTONE -gt $VERSION ) && ( $MILESTONE -gt 140 ) ]] && echo -e "${Y}You may have to remove and sign back into your account(s) after downgrading. Continuing anyways...${N}"
+  confirm_irreversible "This will reinstall ChromeOS $VERSION and overwrite the inactive partition. This cannot be undone once it starts." \
+    || fail "${R}Exiting...${N}"
   askBranch
   getImageLink
 
@@ -253,9 +179,9 @@ installCros() {
   [[ -d modmium ]] && rm -rf modmium
   if [[ -d /root/.ssh ]]; then
     [[ ! -d /home/chronos/user/.ssh ]] && mkdir /home/chronos/user/.ssh
-    git clone --depth 1 -b $branch --single-branch git@github.com:crosmium/modmium.git || fail "${R}Failed to clone repository, exiting...${N}"
+    git clone --depth 1 -b $branch --single-branch $MODMIUM_REPO_SSH || fail "${R}Failed to clone repository, exiting...${N}"
   else
-    git clone --depth 1 -b $branch --single-branch https://github.com/crosmium/modmium.git || fail "${R}Failed to clone repository, exiting...${N}"
+    git clone --depth 1 -b $branch --single-branch $MODMIUM_REPO_HTTPS || fail "${R}Failed to clone repository, exiting...${N}"
   fi
   echo -e "${G}Successfully cloned repository!${N} Dropping new files..."
 
@@ -310,10 +236,7 @@ installCros() {
   umount mnt
   cd .. && rm -rf modmium
   sync
-  echo -e "Would you like to powerwash? (Can prevent Modmium from failing to boot the newly switched version)"
-  echo -ne "[y/N]: "
-  read pwr
-  if [[ "$pwr" =~ ^[Yy]$ ]]; then
+  if confirm_destructive "Would you like to powerwash? (Can prevent Modmium from failing to boot the newly switched version)"; then
     echo -e "Your device ${R}will${N} powerwash on next boot."
     echo "fast safe keepimg" > /mnt/stateful_partition/factory_install_reset
     sleep 0.3
@@ -322,15 +245,12 @@ installCros() {
     sleep 0.3
   fi
   # this is for compatability with other chromeos versions
-echo -e "${Y}Remove developer packages for compatibility with other ChromeOS versions? [Y/n]${N}"
-read -r
-if [[ ! $REPLY =~ ^[Nn]$ ]]; then
-  echo -e "${G}Uninstalling packages...${N}"
-  printf 'y\n' | dev_install --uninstall
-  rm -f /mnt/stateful_partition/.devinstall_complete
-else
-  echo -e "${B}Keeping packages installed.${N}"
-fi
+  if confirm_destructive "Remove developer packages for compatibility with other ChromeOS versions?"; then
+    run_with_feedback "Uninstalling packages..." bash -c "printf 'y\n' | dev_install --uninstall"
+    rm -f $DEVINSTALL_MARKER
+  else
+    echo -e "${B}Keeping packages installed.${N}"
+  fi
   echo -e "Switching active kernel..."
   activekern=$(get_booted_kernnum)
   inactivekern=$(opposite_num "${activekern}")
@@ -371,10 +291,7 @@ toggleBootPriority(){
     newKern=2
   fi
   stty echo
-  echo -e "Are you sure you want to switch your boot kernel to '${intdis_prefix}${newKern}'?"
-  echo -ne "[y/N]: "
-  read -r iamverysure
-  if [[ "$iamverysure" =~ ^[Yy]$ ]]; then
+  if confirm_destructive "This will switch your active boot kernel to '${intdis_prefix}${newKern}' and reboot. Are you sure?"; then
     echo -e "Continuing... \n"
     sleep 0.3
   else
@@ -399,10 +316,7 @@ toggleBootPriority(){
   fi
 
   sync
-  echo -e "Would you like to powerwash? (Can prevent Modmium from failing to boot the newly switched version)"
-  echo -ne "[y/N]: "
-  read -r pwr
-  if [[ "$pwr" =~ ^[Yy]$ ]]; then
+  if confirm_destructive "Would you like to powerwash? (Can prevent Modmium from failing to boot the newly switched version)"; then
     echo -e "Your device ${R}will${N} powerwash on next boot."
     echo "fast safe keepimg" > /mnt/stateful_partition/factory_install_reset
     sleep 0.3
@@ -411,17 +325,12 @@ toggleBootPriority(){
     sleep 0.3
   fi
   # this is for compatability with other chromeos versions
-echo ""
-echo -e "${Y}Would you like to remove developer packages for compatibility with other ChromeOS versions?${N}"
-echo -ne "[y/N]: "
-read -r devp
-if [[ "$devp" =~ ^[Yy]$ ]]; then
-  echo -e "${G}Uninstalling packages...${N}"
-  printf 'y\n' | dev_install --uninstall
-  rm -f /mnt/stateful_partition/.devinstall_complete
-else
-  echo -e "${B}Keeping packages installed.${N}"
-fi
+  if confirm_destructive "Would you like to remove developer packages for compatibility with other ChromeOS versions?"; then
+    run_with_feedback "Uninstalling packages..." bash -c "printf 'y\n' | dev_install --uninstall"
+    rm -f $DEVINSTALL_MARKER
+  else
+    echo -e "${B}Keeping packages installed.${N}"
+  fi
   echo -e "Switching active kernel..."
   cgpt add $intdis -i $currentKern -P 1 -S 1 -T 0
   cgpt add $intdis -i $newKern -P 15 -S 0 -T 15
@@ -464,4 +373,3 @@ menu_reset
 clear
 full_menu
 tput cnorm
-selector

--- a/mod-files/usr/bin/update-modmium.sh
+++ b/mod-files/usr/bin/update-modmium.sh
@@ -213,9 +213,11 @@ installCros() {
   [[ -d /usr/share/vboot/userkeys ]] && cp -r /usr/share/vboot/userkeys mnt/usr/share/vboot
 
   # now to copy relevant files to new root
-  for file in /bootsplash /.branch; do
-    [[ -d $file || -f $file ]] && cp -r $file mnt
-  done
+  [[ -d /bootsplash || -f /bootsplash ]] && cp -r /bootsplash mnt
+  # write the branch just installed, not the old root's /.branch - otherwise
+  # switching branches via "Change ChromeOS Version" would silently keep
+  # reporting the previous branch after the reinstall.
+  echo "$branch" > mnt/.branch
   [[ -d /nix ]] && mkdir mnt/nix # we don't copy contents because the actual contents are in stateful
   echo -e "${B}Copy root's files to new root? [Y/n]${N}"
   read -rep ""

--- a/mod-files/usr/bin/update-modmium.sh
+++ b/mod-files/usr/bin/update-modmium.sh
@@ -50,6 +50,38 @@ askBranch(){
   echo # weird UI glitch if this isn't here, idk man
 }
 
+askRepo(){
+  repofile="$(cat /.repo 2>/dev/null)"
+  [[ $repofile ]] || repofile="official"
+  echo -e "[If you don't know what this means, just press enter]"
+  if [[ $repofile == "official" ]]; then
+    echo -ne "Repo to update from (${B}official${N}, or a custom owner/repo e.g. someuser/modmium): "
+  else
+    echo -ne "Repo to update from (official, or a custom owner/repo) [current: ${B}$repofile${N}]: "
+  fi
+  read -rep "" reporeq
+  case $reporeq in
+    official)
+      repo="official"
+      ;;
+    "")
+      repo="$repofile"
+      ;;
+    *)
+      repo="$reporeq"
+      ;;
+  esac
+  if [[ "$repo" == "official" ]]; then
+    repoSSH="$MODMIUM_REPO_SSH"
+    repoHTTPS="$MODMIUM_REPO_HTTPS"
+  else
+    repoSSH="git@github.com:${repo}.git"
+    repoHTTPS="https://github.com/${repo}.git"
+  fi
+  echo "$repo" > /.repo
+  echo # weird UI glitch if this isn't here, idk man
+}
+
 dropModFiles() {
   modFiles=$(find /mnt/stateful_partition/git/modmium/mod-files -mindepth 1 -name "*")
   for file in $modFiles; do
@@ -73,14 +105,15 @@ updateModmium() {
   stty echo
   export PATH="${PATH}:/usr/local/libexec/git-core" # just in case, so we know git https will work
   askBranch
+  askRepo
   mkdir -p /mnt/stateful_partition/git
   cd /mnt/stateful_partition/git
   [[ -d modmium ]] && rm -rf modmium
   if [[ -d /root/.ssh ]]; then
     [[ ! -d /home/chronos/user/.ssh ]] && mkdir /home/chronos/user/.ssh
-    git clone --depth 1 -b $branch --single-branch $MODMIUM_REPO_SSH || fail "${R}Failed to clone repository, exiting...${N}"
+    git clone --depth 1 -b $branch --single-branch $repoSSH || fail "${R}Failed to clone repository, exiting...${N}"
   else
-    git clone --depth 1 -b $branch --single-branch $MODMIUM_REPO_HTTPS || fail "${R}Failed to clone repository, exiting...${N}"
+    git clone --depth 1 -b $branch --single-branch $repoHTTPS || fail "${R}Failed to clone repository, exiting...${N}"
   fi
   echo -e "${G}Successfully cloned repository!${N} Dropping new files..."
   dropModFiles || fail "${R}Failed to drop updated files, please make an issue report on https://github.com/crosmium/modmium with details of changes you made, if any...${N}"
@@ -124,6 +157,7 @@ installCros() {
   confirm_irreversible "This will reinstall ChromeOS $VERSION and overwrite the inactive partition. This cannot be undone once it starts." \
     || fail "${R}Exiting...${N}"
   askBranch
+  askRepo
   getImageLink
 
   installKern=${intdis_prefix}$(opposite_num $(get_booted_kernnum))
@@ -179,9 +213,9 @@ installCros() {
   [[ -d modmium ]] && rm -rf modmium
   if [[ -d /root/.ssh ]]; then
     [[ ! -d /home/chronos/user/.ssh ]] && mkdir /home/chronos/user/.ssh
-    git clone --depth 1 -b $branch --single-branch $MODMIUM_REPO_SSH || fail "${R}Failed to clone repository, exiting...${N}"
+    git clone --depth 1 -b $branch --single-branch $repoSSH || fail "${R}Failed to clone repository, exiting...${N}"
   else
-    git clone --depth 1 -b $branch --single-branch $MODMIUM_REPO_HTTPS || fail "${R}Failed to clone repository, exiting...${N}"
+    git clone --depth 1 -b $branch --single-branch $repoHTTPS || fail "${R}Failed to clone repository, exiting...${N}"
   fi
   echo -e "${G}Successfully cloned repository!${N} Dropping new files..."
 
@@ -214,10 +248,11 @@ installCros() {
 
   # now to copy relevant files to new root
   [[ -d /bootsplash || -f /bootsplash ]] && cp -r /bootsplash mnt
-  # write the branch just installed, not the old root's /.branch - otherwise
-  # switching branches via "Change ChromeOS Version" would silently keep
-  # reporting the previous branch after the reinstall.
+  # write the branch/repo just installed, not the old root's /.branch and
+  # /.repo - otherwise switching branches or repos via "Change ChromeOS
+  # Version" would silently keep reporting the previous ones afterward.
   echo "$branch" > mnt/.branch
+  echo "$repo" > mnt/.repo
   [[ -d /nix ]] && mkdir mnt/nix # we don't copy contents because the actual contents are in stateful
   echo -e "${B}Copy root's files to new root? [Y/n]${N}"
   read -rep ""

--- a/mod-files/usr/bin/vt-mosh.sh
+++ b/mod-files/usr/bin/vt-mosh.sh
@@ -65,6 +65,9 @@ misc(){
 apps(){
   runscript /usr/bin/mosh-apps.sh
 }
+doctor(){
+  runscript /usr/bin/mosh-doctor.sh
+}
 # -- MAIN SCRIPT --
 tput civis # :whale:
 
@@ -74,8 +77,8 @@ menu_logo() {
 
 menu_reset() {
     menuText="\n${D}If you'd like skip this menu by default, run 'touch /usr/local/.defaultvt'${N}\n"
-  options=("Root Shell" "Chronos Shell" "Manage Modmium" "Edit ${Y}Device Policies${N}" "Edit ${G}User Policies${N}" "Apps" "Misc" "Exit")
-  functions=("rootsh" "chronosh" "update" "devpol" "userpol" "apps" "misc" "quit")
+  options=("Root Shell" "Chronos Shell" "Manage Modmium" "Edit ${Y}Device Policies${N}" "Edit ${G}User Policies${N}" "Apps" "Misc" "Health Check" "Exit")
+  functions=("rootsh" "chronosh" "update" "devpol" "userpol" "apps" "misc" "doctor" "quit")
   num_options=${#options[@]}
 }
 
@@ -83,4 +86,3 @@ menu_reset
 clear
 full_menu
 tput cnorm
-selector

--- a/mod-files/usr/bin/vt-mosh.sh
+++ b/mod-files/usr/bin/vt-mosh.sh
@@ -65,9 +65,6 @@ misc(){
 apps(){
   runscript /usr/bin/mosh-apps.sh
 }
-doctor(){
-  runscript /usr/bin/mosh-doctor.sh
-}
 # -- MAIN SCRIPT --
 tput civis # :whale:
 
@@ -77,8 +74,8 @@ menu_logo() {
 
 menu_reset() {
     menuText="\n${D}If you'd like skip this menu by default, run 'touch /usr/local/.defaultvt'${N}\n"
-  options=("Root Shell" "Chronos Shell" "Manage Modmium" "Edit ${Y}Device Policies${N}" "Edit ${G}User Policies${N}" "Apps" "Misc" "Health Check" "Exit")
-  functions=("rootsh" "chronosh" "update" "devpol" "userpol" "apps" "misc" "doctor" "quit")
+  options=("Root Shell" "Chronos Shell" "Manage Modmium" "Edit ${Y}Device Policies${N}" "Edit ${G}User Policies${N}" "Apps" "Misc" "Exit")
+  functions=("rootsh" "chronosh" "update" "devpol" "userpol" "apps" "misc" "quit")
   num_options=${#options[@]}
 }
 

--- a/mod-files/usr/lib/libmosh.sh
+++ b/mod-files/usr/lib/libmosh.sh
@@ -27,6 +27,33 @@ D=$'\033[1;90m'
 UN=$'\033[4m' #underline
 RUN=$'\033[24m' #reset underline
 MILESTONE=$(grep MILESTONE /etc/lsb-release | cut -d= -f2 | tr -d '\r')
+BOARD="$(grep '^CHROMEOS_RELEASE_DESCRIPTION=' /etc/lsb-release | awk '{print $NF}')"
+
+# -- Shared constants (scripts that source this file should use these instead --
+# -- of hardcoding the same URLs/paths again). modmium.sh can't use these since --
+# -- it runs before this file (or the rest of the repo) exists on disk.        --
+MODMIUM_REPO_SSH="git@github.com:crosmium/modmium.git"
+MODMIUM_REPO_HTTPS="https://github.com/crosmium/modmium.git"
+RECOVERY_JSON_URL="https://cdn.jsdelivr.net/gh/crosbreaker/chromeos-releases-data/data.json"
+DEVINSTALL_MARKER="/mnt/stateful_partition/.devinstall_complete"
+MODMIUM_LOG="/mnt/stateful_partition/modmium.log"
+
+# log_action <message> — appends a timestamped line to the shared Modmium
+# log (survives powerwash-adjacent debugging since it's a plain file people
+# can be asked to attach to a support request). Never fails the caller.
+log_action() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$(basename -- "$0")] $1" >> "$MODMIUM_LOG" 2>/dev/null
+}
+
+# -- Default error handler. Scripts with special cleanup needs (restoring a --
+# -- firmware backup, restarting powerd, etc.) can still define their own   --
+# -- fail() after sourcing this file, since the later definition wins.      --
+fail() {
+  log_action "FAILED: $1"
+  echo -e "$1"
+  sleep 3
+  exit 1
+}
 
 # STOLEN CODE FROM BR0KER TO GET MILESTONE :3
 get_largest_cros_blockdev() {
@@ -83,10 +110,141 @@ get_fixed_dst_drive() {
   echo "${dev}"
 }
 
+get_booted_kernnum() {
+  if (( $(cgpt show -n "$intdis" -i 2 -P) > $(cgpt show -n "$intdis" -i 4 -P) )); then
+    echo -n 2
+  else
+    echo -n 4
+  fi
+}
+get_booted_rootnum() {
+  echo $(( $(get_booted_kernnum) + 1 ))
+}
+opposite_num() {
+  case $1 in
+    2) echo -n 4 ;;
+    3) echo -n 5 ;;
+    4) echo -n 2 ;;
+    5) echo -n 3 ;;
+    *) echo -n "skid" ;;
+  esac
+}
+
+convertToExt4() {
+  echo -e "${Y}Converting new RootFS to ext4...${N}"
+  installRoot=${intdis_prefix}$(opposite_num $(get_booted_rootnum))
+  tune2fs -O has_journal -J size=16 ${installRoot} || fail "${R}Conversion failed!${N}"
+  e2fsck -fDy ${installRoot} || fail "${R}Conversion failed!${N}"
+  tune2fs -O extents ${installRoot} || fail "${R}Conversion failed!${N}"
+  e2fsck -fDy ${installRoot} || fail "${R}Conversion failed!${N}"
+  resize2fs -b ${installRoot} || fail "${R}Conversion failed!${N}"
+  e2fsck -fDy ${installRoot} || fail "${R}Conversion failed!${N}"
+  tune2fs -O metadata_csum ${installRoot} || fail "${R}Conversion failed!${N}"
+  e2fsck -fDy ${installRoot} || fail "${R}Conversion failed!${N}"
+  echo -e "${G}Conversion succeeded!${N}"
+  sync;sync;sync # oh how i love you sync, hopefully what is above this will make us less reliant on your help <3
+}
+
+# Looks up a matching stable-channel recovery image URL for $BOARD/$VERSION.
+# Sets $recoveryUrl on success, fails (with an actionable message) otherwise.
+getImageLink() {
+  echo -e "${G}Checking crosbreaker/chromeos-releases-data for recovery image URL...${N}"
+  recoveryUrl=$(curl -sL $RECOVERY_JSON_URL | jq -r --arg board $BOARD --arg ver $VERSION '
+    .[$board].images // []
+    | map(select(
+    .channel == "stable-channel" and
+    (.chrome_version | startswith($ver + "."))
+    ))
+    | sort_by(.last_modified)
+    | last
+    | .url // empty
+    ')
+  if [[ -n $recoveryUrl && $recoveryUrl =~ dl\.google\.com ]]; then
+    echo -e "${G}Recovery URL found!${N}"
+    sleep 1
+  else
+    fail "${R}No recovery image found for ChromeOS ${VERSION} on this board. Double check the version number, or try a different one at https://cros.tech/${N}"
+  fi
+}
+
+# confirm_destructive "warning" — shows a warning, then a plain y/N prompt
+# (default: no). Returns success only if the user typed y/Y.
+confirm_destructive() {
+  echo -e "${Y}$1${N}"
+  echo -ne "[y/N]: "
+  read -r reply
+  if [[ "$reply" =~ ^[Yy]$ ]]; then
+    log_action "CONFIRMED: $1"
+    return 0
+  else
+    log_action "DECLINED: $1"
+    return 1
+  fi
+}
+
+# confirm_irreversible "warning" — for big, hard/impossible-to-undo steps
+# (flashing firmware, wiping a partition, reinstalling the OS). Requires a
+# double press of 'y' in quick succession, same as modmium.sh's install
+# confirmation, so it can't be triggered by someone leaning on Enter.
+confirm_irreversible() {
+  echo -e "${R}$1${N}"
+  read -r -n 2 -s -p "Double tap y to continue, or press any other key to cancel: " confirmation
+  echo ""
+  if [[ "$confirmation" == "yy" ]]; then
+    log_action "CONFIRMED (irreversible): $1"
+    return 0
+  else
+    log_action "DECLINED (irreversible): $1"
+    return 1
+  fi
+}
+
+# run_with_feedback "message" cmd [args...] — prints a message before running
+# a command so nothing happens silently, then reports whether it succeeded.
+# The command's own output (and stdin, if piped in by the caller) still
+# passes straight through.
+run_with_feedback() {
+  local msg="$1"
+  shift
+  echo -e "${Y}${msg}${N}"
+  log_action "START: $msg"
+  "$@"
+  local status=$?
+  if [[ $status -eq 0 ]]; then
+    echo -e "${G}Done.${N}"
+    log_action "OK: $msg"
+  else
+    echo -e "${R}That step failed (exit code ${status}).${N}"
+    log_action "FAILED (exit ${status}): $msg"
+  fi
+  return $status
+}
+
+# ensure_deps <package> [package...] — installs the ChromeOS dev packages
+# needed by MOSH scripts (git, file, protobuf-python, etc), downloading the
+# base dev image only once (tracked by $DEVINSTALL_MARKER) and always
+# reporting progress instead of running silently.
+ensure_deps() {
+  source /etc/profile # required to get emerge working in mosh
+  if [[ ! -f $DEVINSTALL_MARKER ]]; then
+    run_with_feedback "Setting up ChromeOS developer packages for the first time — this can take a few minutes, please be patient..." \
+      bash -c "printf 'y\n\nn' | dev_install --reinstall" \
+      || fail "${R}Could not install dependencies. Connect to the internet and try again.${N}"
+    touch $DEVINSTALL_MARKER
+  fi
+  ldconfig # reload shared libraries to include python libs
+  run_with_feedback "Installing: $* ..." emerge "$@" \
+    || fail "${R}Could not install ($*). Connect to the internet and try again.${N}"
+  if [[ -d /usr/local/usr/share/git-core/templates ]]; then
+    cp -r /usr/local/usr/share/git-core/templates /usr/share/git-core # fix the warning about git templates being missing
+  fi
+}
+
 runscript() {
   stty echo
   tput cnorm
   echo "$1"
+  log_action "RUN: $1"
   employ as_system "$1"
   menu_reset
   full_menu
@@ -123,6 +281,7 @@ runscriptnoroot() {
   stty echo
   tput cnorm
   echo "$1"
+  log_action "RUN (noroot): $1"
   employ "$1"
   menu_reset
   full_menu

--- a/modmium.sh
+++ b/modmium.sh
@@ -17,6 +17,7 @@ FLAGS $@
 [[ $QUICKINSTALL == $FLAGS_TRUE ]] && export FLAG_userkeys=$FLAGS_FALSE
 
 fail(){
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] [modmium.sh] FAILED: $1" >> "$MODMIUM_LOG" 2>/dev/null
   echo -e "$1"
   if [[ $2 != "keepflag" ]]; then
     vpd -d dev_firmware
@@ -43,12 +44,94 @@ RUN=$'\033[24m' #reset underline
 MILESTONE=$(grep MILESTONE /etc/lsb-release | cut -d= -f2 | tr -d '\r')
 [[ $QUICKINSTALL == $FLAGS_TRUE ]] && menu_text="Modmium Install Script! (Quickinstall)"
 
+# -- Constants --
+# These are hardcoded (instead of sourced from a shared lib like libmosh.sh)
+# because this script runs before Modmium's repo exists on disk at all -
+# it's the thing that clones the repo in the first place.
+MODMIUM_REPO_SSH="git@github.com:crosmium/modmium.git"
+MODMIUM_REPO_HTTPS="https://github.com/crosmium/modmium.git"
+RECOVERY_JSON_URL="https://cdn.jsdelivr.net/gh/crosbreaker/chromeos-releases-data/data.json"
+DEVINSTALL_MARKER="/mnt/stateful_partition/.devinstall_complete"
+STREAM_PY_URL="https://modmium.dev/tools/stream.py"
+MODMIUM_LOG="/mnt/stateful_partition/modmium.log" # same path libmosh.sh logs to post-install
+
+log_action() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] [modmium.sh] $1" >> "$MODMIUM_LOG" 2>/dev/null
+}
+
+# confirm_destructive "warning" — plain y/N prompt (default: no).
+confirm_destructive() {
+  echo -e "${Y}$1${N}"
+  echo -ne "[y/N]: "
+  read -r reply
+  if [[ "$reply" =~ ^[Yy]$ ]]; then
+    log_action "CONFIRMED: $1"
+    return 0
+  else
+    log_action "DECLINED: $1"
+    return 1
+  fi
+}
+
+# confirm_irreversible "warning" — for big, hard/impossible-to-undo steps.
+# Requires a double press of 'y' in quick succession (same idea as
+# askConfirmation() below) so it can't be triggered by leaning on Enter.
+confirm_irreversible() {
+  echo -e "${R}$1${N}"
+  read -r -n 2 -s -p "Double tap y to continue, or press any other key to cancel: " confirmation
+  echo ""
+  if [[ "$confirmation" == "yy" ]]; then
+    log_action "CONFIRMED (irreversible): $1"
+    return 0
+  else
+    log_action "DECLINED (irreversible): $1"
+    return 1
+  fi
+}
+
+# run_with_feedback "message" cmd [args...] — never run a long/silent step
+# without telling the user it's happening first.
+run_with_feedback() {
+  local msg="$1"
+  shift
+  echo -e "${Y}${msg}${N}"
+  log_action "START: $msg"
+  "$@"
+  local status=$?
+  if [[ $status -eq 0 ]]; then
+    echo -e "${G}Done.${N}"
+    log_action "OK: $msg"
+  else
+    echo -e "${R}That step failed (exit code ${status}).${N}"
+    log_action "FAILED (exit ${status}): $msg"
+  fi
+  return $status
+}
+
+# ensure_deps <package> [package...] — installs the ChromeOS dev packages
+# needed to clone/build Modmium, downloading the base dev image only once
+# (tracked by $DEVINSTALL_MARKER) and always reporting progress.
+ensure_deps() {
+  source /etc/profile # required to get emerge working
+  if [[ ! -f $DEVINSTALL_MARKER ]]; then
+    run_with_feedback "Setting up ChromeOS developer packages for the first time — this can take a few minutes, please be patient..." \
+      bash -c "printf 'y\n\nn' | dev_install --reinstall" \
+      || fail "${R}Could not install dependencies. Connect to the internet and try again.${N}" keepflag
+    touch $DEVINSTALL_MARKER
+  fi
+  ldconfig # reload shared libraries to include python libs
+  run_with_feedback "Installing: $* ..." emerge "$@" \
+    || fail "${R}Could not install ($*). Connect to the internet and try again.${N}" keepflag
+  if [[ -d /usr/local/usr/share/git-core/templates ]]; then
+    cp -r /usr/local/usr/share/git-core/templates /usr/share/git-core # fix the warning about git templates being missing
+  fi
+}
+
 # -- skidded from modmium-update.sh --
 BOARD="$(grep '^CHROMEOS_RELEASE_DESCRIPTION=' /etc/lsb-release | awk '{print $NF}')"
 getImageLink(){
-  jsonLink="https://cdn.jsdelivr.net/gh/crosbreaker/chromeos-releases-data/data.json"
   echo -e "${G}Checking crosbreaker/chromeos-releases-data for recovery image URL...${N}"
-  recoveryUrl=$(curl -sL $jsonLink | jq -r --arg board $BOARD --arg ver $VERSION '
+  recoveryUrl=$(curl -sL $RECOVERY_JSON_URL | jq -r --arg board $BOARD --arg ver $VERSION '
     .[$board].images // []
     | map(select(
     .channel == "stable-channel" and
@@ -62,7 +145,7 @@ getImageLink(){
     echo -e "${G}Recovery URL found!${N}"
     sleep 1
   else
-    fail "${R}Recovery URL not found or invalid :(${N}"
+    fail "${R}No recovery image found for ChromeOS ${VERSION} on this board. Double check the version number, or ask in the Discord (${Y}discord.crosbreaker.com${R}).${N}"
   fi
 }
 
@@ -129,14 +212,12 @@ installCros() {
   read -rep "" VERSION
   [[ $VERSION =~ ^[0-9]+$ ]] || fail "${R}Version must be numeric, exiting...${N}" keepflag
   if [[ $VERSION -lt 131 ]]; then
-    echo -e "${R}WARNING. VERSIONS BELOW 131 ARE NOT SUPPORTED.${N}\nDo not make an issue report if you run into problems."
-    echo -e "${B}Continue anyways? [y/N]${N}"
-    read -rep ""
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-      echo -e "${B}Continuing...${N}"
-    else
-      fail "${R}Exiting...${N}" keepflag
-    fi
+    confirm_destructive "WARNING. VERSIONS BELOW 131 ARE NOT SUPPORTED.\nDo not make an issue report if you run into problems.\nContinue anyways?" \
+      || fail "${R}Exiting...${N}" keepflag
+  fi
+  if [[ $QUICKINSTALL == $FLAGS_FALSE ]]; then
+    confirm_irreversible "This will install ChromeOS $VERSION onto the inactive partition. This cannot be undone once it starts." \
+      || fail "${R}Exiting...${N}" keepflag
   fi
   askBranch
   getImageLink
@@ -156,12 +237,14 @@ installCros() {
   pip install requests &>/dev/null
   streamdir=/root/ # might as well if rootfs verification is already off ig, im keeping this as default just because i don't want to break anything - dmd
   [[ $QUICKINSTALL == $FLAGS_TRUE ]] && streamdir=/usr/local/
-  curl -Lo ${streamdir}stream.py "https://modmium.dev/tools/stream.py"
-  python ${streamdir}stream.py --recovery-url "${recoveryUrl}" --kern-output "${installKern}" --root-output "${installRoot}" || fail "${R}Failed to install ChromeOS, refusing to change boot order, exiting...${N}" keepflag
+  curl -fLo ${streamdir}stream.py "$STREAM_PY_URL" || fail "${R}Failed to download the ChromeOS streaming tool. Connect to the internet and try again.${N}" keepflag
+  run_with_feedback "Streaming ChromeOS $VERSION to disk, this can take several minutes..." \
+    python ${streamdir}stream.py --recovery-url "${recoveryUrl}" --kern-output "${installKern}" --root-output "${installRoot}" \
+    || fail "${R}Failed to install ChromeOS, refusing to change boot order, exiting...${N}" keepflag
   rm -rf .venv
   # thanks lxrd for that python script btw
   echo -e "${G}Removing verity from ChromeOS...${N}"
-  # keydir gets defined in installModmium()
+  # keydir gets defined in modmiumInstall()
   /usr/share/vboot/bin/make_dev_ssd.sh --remove_rootfs_verification --partitions $(opposite_num $(get_booted_kernnum)) --keys ${keydir} &>/dev/null
   futility dump_kernel_config ${installKern} > config.txt
   sed -i "s|cros_secure|cros_secure cros_debug|g" config.txt
@@ -197,9 +280,9 @@ installCros() {
   cd /mnt/stateful_partition/git
   if [[ -d /root/.ssh ]]; then
     [[ ! -d /home/chronos/user/.ssh ]] && mkdir /home/chronos/user/.ssh
-    git clone --depth 1 -b $branch --single-branch git@github.com:crosmium/modmium.git || fail "${R}Failed to clone repository, exiting...${N}" keepflag
+    git clone --depth 1 -b $branch --single-branch $MODMIUM_REPO_SSH || fail "${R}Failed to clone repository, exiting...${N}" keepflag
   else
-    git clone --depth 1 -b $branch --single-branch https://github.com/crosmium/modmium.git || fail "${R}Failed to clone repository, exiting...${N}" keepflag
+    git clone --depth 1 -b $branch --single-branch $MODMIUM_REPO_HTTPS || fail "${R}Failed to clone repository, exiting...${N}" keepflag
   fi
   echo -e "${G}Successfully cloned repository!${N} Dropping new files..."
 
@@ -233,10 +316,7 @@ installCros() {
   cd .. && rm -rf modmium
   sync
   if [[ $QUICKINSTALL == $FLAGS_FALSE ]]; then
-    echo -e "Would you like to powerwash? (Can prevent blackscreening on boot)"
-    echo -ne "[y/N]: "
-    read pwr
-    if [[ "$pwr" =~ ^[Yy]$ ]]; then
+    if confirm_destructive "Would you like to powerwash? (Can prevent blackscreening on boot)"; then
       echo -e "Your device ${R}will${N} powerwash on next boot."
       echo "fast safe keepimg" > /mnt/stateful_partition/factory_install_reset
       sleep 0.3
@@ -248,15 +328,14 @@ installCros() {
     echo -e "${Y}Remove developer packages for compatibility with other ChromeOS versions? [Y/n]${N}"
     read -r
     if [[ ! $REPLY =~ ^[Nn]$ ]]; then
-      echo -e "${G}Uninstalling packages...${N}"
-      printf 'y\n' | dev_install --uninstall
-      rm -f /mnt/stateful_partition/.devinstall_complete
+      run_with_feedback "Uninstalling packages..." bash -c "printf 'y\n' | dev_install --uninstall"
+      rm -f $DEVINSTALL_MARKER
     else
       echo -e "${B}Keeping packages installed.${N}"
     fi
   else
-    printf 'y\n' | dev_install --uninstall
-    rm -f /mnt/stateful_partition/.devinstall_complete
+    run_with_feedback "Uninstalling packages..." bash -c "printf 'y\n' | dev_install --uninstall"
+    rm -f $DEVINSTALL_MARKER
   fi
 
   echo -e "Switching active kernel..."
@@ -324,7 +403,7 @@ checkWP(){
               crossystem wpsw_cur || grep "0" || fail "Failed to disable HWWP."
               flashrom --wp-disable || echo -e "WARNING: SWWP FAILED TO DISABLE! This is a known issue on ARM boards such as corsola and geralt. Modmium can still install because HWWP is disabled, but you may encounter issues later." && read -p "Press enter to continue, or Ctrl+C to abort."
               ;;
-            *) fail "How did we get here..?" ;;
+            *) fail "Got an unexpected AllowUnverifiedRo value ('$setting') from gsctool. Please ask in the Discord (${Y}discord.crosbreaker.com${R}) with this exact message." ;;
           esac
         fi
         fail "HWWP and SWWP are enabled with WP range non-zero, please disable your WP by following this guide: ${G}https://crosmium.dev/HWWP${N}"
@@ -339,19 +418,10 @@ checkAPROV(){
     case $setting in
       Always) echo -e "APROV is currently ${G}DISABLED${N}, continuing..." ;;
       Never) fail "APROV is currently ${R}ENABLED${N}. If you're seeing this, WP is off but APROV is on and rebooting will ${R}${UN}BRICK YOUR DEVICE${RUN}${N}.\n Disable APROV immediately by running \`gsctool -a -I AllowUnverifiedRo:always\`" ;;
-      *) fail "How did we get here..?" ;;
+      *) fail "Got an unexpected AllowUnverifiedRo value ('$setting') from gsctool. Please ask in the Discord (${Y}discord.crosbreaker.com${R}) with this exact message." ;;
     esac
   else
     echo -e "Device is not Ti50, continuing..."
-  fi
-}
-
-askConfirmation(){
-  read -r -n 2 -s -p "Double click y to continue, or hold any other key to quit." confirmation # don't put Y if confirm wants y
-  echo ""
-  if [[ "$confirmation" != "yy" ]]; then
-    echo -e "Denied! exiting.."
-    exit 0
   fi
 }
 
@@ -412,15 +482,7 @@ modmiumInstall(){
     keydir=/usr/share/vboot/devkeys
   fi
   if ! which git &>/dev/null || ! which file &>/dev/null; then
-    echo -e "${R}Dependencies not installed, installing...${N}"
-    source /etc/profile # required to get emerge working
-    if [[ ! -f /mnt/stateful_partition/.devinstall_complete ]]; then
-      printf 'y\n\nn' | dev_install --reinstall || fail "${R}Could not install dependencies. Connect to the internet first.${N}" keepflag
-      touch /mnt/stateful_partition/.devinstall_complete
-    fi
-    ldconfig # reload shared libraries to include python libs
-    emerge git file || fail "${R}Could not install dependencies. Connect to the internet first.${N}" keepflag
-    cp -r /usr/local/usr/share/git-core/templates /usr/share/git-core # fix the warning about git templates being missing
+    ensure_deps git file
   fi
   [[ $FLAGS_userkeys == $FLAGS_TRUE ]] && selUserBackup
   if [[ $QUICKINSTALL == $FLAGS_TRUE ]]; then
@@ -466,15 +528,12 @@ What drive would you like write the backup onto? Type /dev/sdX or sdX not the US
 EOF
       read -ep "Drive: " driveloc
       driveloc="${driveloc%/}"
-      if [[ $driveloc == *"/dev/"* ]]; then
-        mkfs.vfat -I -F 32 $driveloc || fail "${R}Unable to wipe device, exiting...${N}"
-        mkdir -p $BACKUP
-        mount $driveloc $BACKUP || fail "${R}Unable to mount device, exiting...${N}"
-      else
-        mkfs.vfat -I -F 32 /dev/$driveloc || fail "${R}Unable to wipe device, exiting...${N}"
-        mkdir -p /tmp/backupdir
-         mount /dev/$driveloc $BACKUP || fail "${R}Unable to mount device, exiting...${N}"
-      fi
+      [[ $driveloc == *"/dev/"* ]] || driveloc="/dev/$driveloc"
+      confirm_destructive "This will ERASE EVERYTHING on ${driveloc}. Are you sure this is the right drive?" \
+        || fail "${R}Exiting...${N}" keepflag
+      mkfs.vfat -I -F 32 $driveloc || fail "${R}Unable to wipe device, exiting...${N}"
+      mkdir -p $BACKUP
+      mount $driveloc $BACKUP || fail "${R}Unable to mount device, exiting...${N}"
        if ! ( [ -d ${BACKUP} ] && touch ${BACKUP}/.test ); then
         fail "${R}Unable to write to backup, exiting...${N}"
       fi
@@ -562,8 +621,8 @@ EOF
   checkWP
   checkAPROV # Kinda useless now, no harm in keeping though!
 
-  echo -e "${G}Are you sure you want to flash DevFW firmware?${N}"
-  askConfirmation
+  confirm_irreversible "Are you sure you want to flash DevFW firmware? This changes your boot keys and cannot be undone without a factory firmware restore." \
+    || { echo -e "Denied! exiting.."; exit 0; }
 
   [[ $QUICKINSTALL == $FLAGS_FALSE ]] && echo -e "Getting backup selection..."
   selectBackup

--- a/test/libmosh.bats
+++ b/test/libmosh.bats
@@ -1,0 +1,219 @@
+#!/usr/bin/env bats
+# Tests for the pure/testable logic in mod-files/usr/lib/libmosh.sh.
+#
+# libmosh.sh is written to run on a real Modmium device (it sources
+# /usr/share/misc/shflags, reads /.branch, /usr/share/.version, etc, none of
+# which exist here), but none of that is fatal to source it - bash just
+# prints "No such file" warnings and leaves the corresponding variables
+# empty, so the actual functions we care about testing still load fine.
+
+setup() {
+  ROOT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  # libmosh.sh reads a few device-only files at the top (stateful, /.branch,
+  # /usr/share/misc/shflags, ...) that don't exist off-device; those failures
+  # are harmless (the corresponding variables just end up empty) but bats
+  # runs under errexit, so swallow them explicitly rather than aborting.
+  source "$ROOT_DIR/mod-files/usr/lib/libmosh.sh" 2>/dev/null || true
+
+  # Route the shared log to a scratch file instead of the real (root-owned,
+  # ChromeOS-only) stateful partition path.
+  MODMIUM_LOG="$BATS_TEST_TMPDIR/modmium.log"
+  DEVINSTALL_MARKER="$BATS_TEST_TMPDIR/.devinstall_complete"
+}
+
+# -- opposite_num --
+
+@test "opposite_num maps kernel/root partition numbers to their pair" {
+  [[ "$(opposite_num 2)" == "4" ]]
+  [[ "$(opposite_num 4)" == "2" ]]
+  [[ "$(opposite_num 3)" == "5" ]]
+  [[ "$(opposite_num 5)" == "3" ]]
+}
+
+@test "opposite_num returns 'skid' for anything else" {
+  [[ "$(opposite_num 99)" == "skid" ]]
+  [[ "$(opposite_num "")" == "skid" ]]
+}
+
+# -- format_part_number --
+
+@test "format_part_number adds a 'p' separator only when the disk name ends in a digit" {
+  [[ "$(format_part_number /dev/sda 1)" == "/dev/sda1" ]]
+  [[ "$(format_part_number /dev/mmcblk0 1)" == "/dev/mmcblk0p1" ]]
+  [[ "$(format_part_number /dev/nvme0n1 3)" == "/dev/nvme0n1p3" ]]
+}
+
+# -- confirm_destructive --
+
+@test "confirm_destructive succeeds on y/Y and fails on anything else (default: no)" {
+  run bash -c 'source "'"$ROOT_DIR"'/mod-files/usr/lib/libmosh.sh" 2>/dev/null; confirm_destructive "test" <<< "y"'
+  [ "$status" -eq 0 ]
+
+  run bash -c 'source "'"$ROOT_DIR"'/mod-files/usr/lib/libmosh.sh" 2>/dev/null; confirm_destructive "test" <<< "Y"'
+  [ "$status" -eq 0 ]
+
+  run bash -c 'source "'"$ROOT_DIR"'/mod-files/usr/lib/libmosh.sh" 2>/dev/null; confirm_destructive "test" <<< "n"'
+  [ "$status" -eq 1 ]
+
+  run bash -c 'source "'"$ROOT_DIR"'/mod-files/usr/lib/libmosh.sh" 2>/dev/null; confirm_destructive "test" <<< ""'
+  [ "$status" -eq 1 ]
+}
+
+# -- confirm_irreversible --
+
+@test "confirm_irreversible only succeeds on a literal double 'yy'" {
+  run bash -c 'source "'"$ROOT_DIR"'/mod-files/usr/lib/libmosh.sh" 2>/dev/null; confirm_irreversible "test" <<< "yy"'
+  [ "$status" -eq 0 ]
+
+  run bash -c 'source "'"$ROOT_DIR"'/mod-files/usr/lib/libmosh.sh" 2>/dev/null; confirm_irreversible "test" <<< "y"'
+  [ "$status" -eq 1 ]
+
+  run bash -c 'source "'"$ROOT_DIR"'/mod-files/usr/lib/libmosh.sh" 2>/dev/null; confirm_irreversible "test" <<< "no"'
+  [ "$status" -eq 1 ]
+}
+
+# -- run_with_feedback --
+
+@test "run_with_feedback passes through the wrapped command's exit status" {
+  run run_with_feedback "msg" true
+  [ "$status" -eq 0 ]
+
+  run run_with_feedback "msg" false
+  [ "$status" -eq 1 ]
+
+  run run_with_feedback "msg" bash -c 'exit 7'
+  [ "$status" -eq 7 ]
+}
+
+@test "run_with_feedback reports both the message and success/failure" {
+  run run_with_feedback "doing the thing" true
+  [[ "$output" == *"doing the thing"* ]]
+  [[ "$output" == *"Done."* ]]
+
+  run run_with_feedback "doing the thing" false
+  [[ "$output" == *"failed"* ]]
+}
+
+# -- log_action / fail logging --
+
+@test "log_action appends a timestamped line to MODMIUM_LOG" {
+  log_action "hello world"
+  [ -f "$MODMIUM_LOG" ]
+  grep -q "hello world" "$MODMIUM_LOG"
+}
+
+@test "confirm_destructive logs whether it was confirmed or declined" {
+  confirm_destructive "do the thing" <<< "y" || true
+  grep -q "CONFIRMED: do the thing" "$MODMIUM_LOG"
+
+  confirm_destructive "do the thing" <<< "n" || true
+  grep -q "DECLINED: do the thing" "$MODMIUM_LOG"
+}
+
+@test "fail logs, prints the message, and exits non-zero" {
+  run bash -c 'source "'"$ROOT_DIR"'/mod-files/usr/lib/libmosh.sh" 2>/dev/null; MODMIUM_LOG="'"$MODMIUM_LOG"'"; fail "boom"'
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"boom"* ]]
+  grep -q "FAILED: boom" "$MODMIUM_LOG"
+}
+
+# -- ensure_deps gating logic (dev_install/emerge/ldconfig stubbed out) --
+
+setup_ensure_deps_stubs() {
+  dev_install() { return 0; }
+  emerge() { return 0; }
+  ldconfig() { return 0; }
+}
+
+@test "ensure_deps bootstraps dev packages only once, then just emerges" {
+  setup_ensure_deps_stubs
+  # ensure_deps runs the dev_install step inside a nested `bash -c` (to
+  # support piping answers into it), so the stub needs to be exported for
+  # that child shell to see it.
+  export DEV_INSTALL_CALLS="$BATS_TEST_TMPDIR/dev_install_calls"
+  : > "$DEV_INSTALL_CALLS"
+  dev_install() { echo called >> "$DEV_INSTALL_CALLS"; return 0; }
+  export -f dev_install
+
+  [ ! -f "$DEVINSTALL_MARKER" ]
+  ensure_deps somepkg
+  [ -f "$DEVINSTALL_MARKER" ]
+  [ "$(wc -l < "$DEV_INSTALL_CALLS")" -eq 1 ]
+
+  ensure_deps somepkg
+  [ "$(wc -l < "$DEV_INSTALL_CALLS")" -eq 1 ] # not called again, marker already present
+}
+
+@test "ensure_deps fails cleanly if dev_install fails" {
+  setup_ensure_deps_stubs
+  dev_install() { return 1; }
+  export -f dev_install
+
+  run ensure_deps somepkg
+  [ "$status" -ne 0 ]
+  [ ! -f "$DEVINSTALL_MARKER" ]
+}
+
+@test "ensure_deps fails cleanly if emerge fails" {
+  setup_ensure_deps_stubs
+  emerge() { return 1; }
+
+  run ensure_deps somepkg
+  [ "$status" -ne 0 ]
+}
+
+# -- full_menu/selector dispatch --
+#
+# Regression test for a real bug found while auditing the menu scripts:
+# full_menu() already calls selector() itself once its input loop breaks on
+# Enter, so a script whose *own* bottom section calls `full_menu` and then
+# *also* calls `selector` again ends up dispatching the selected action
+# twice for any handler that returns normally (doesn't exit or loop back
+# into its own menu_reset+full_menu). Confirmed by reproducing it against
+# the pre-fix pattern before removing the redundant trailing `selector`
+# calls from every mod-files script that had it (except cr3nroll.sh, which
+# is vendored from a separate project and manages its own menu loop).
+
+@test "a selected action fires exactly once when the script only calls full_menu (not also selector)" {
+  cat > "$BATS_TEST_TMPDIR/menu.sh" <<EOF
+source "$ROOT_DIR/mod-files/usr/lib/libmosh.sh" 2>/dev/null
+counter="$BATS_TEST_TMPDIR/counter"
+: > "\$counter"
+doThing(){ echo called >> "\$counter"; }
+menu_reset(){ options=("Do Thing" "Exit"); functions=("doThing" "quit"); num_options=\${#options[@]}; menuText=""; }
+menu_reset
+clear
+full_menu
+tput cnorm
+EOF
+  printf '\r' | timeout 3 bash "$BATS_TEST_TMPDIR/menu.sh" >/dev/null 2>&1
+  [ "$(wc -l < "$BATS_TEST_TMPDIR/counter")" -eq 1 ]
+}
+
+@test "(documents the bug) an extra trailing selector call double-dispatches the same action" {
+  cat > "$BATS_TEST_TMPDIR/menu_buggy.sh" <<EOF
+source "$ROOT_DIR/mod-files/usr/lib/libmosh.sh" 2>/dev/null
+counter="$BATS_TEST_TMPDIR/counter_buggy"
+: > "\$counter"
+doThing(){ echo called >> "\$counter"; }
+menu_reset(){ options=("Do Thing" "Exit"); functions=("doThing" "quit"); num_options=\${#options[@]}; menuText=""; }
+menu_reset
+clear
+full_menu
+tput cnorm
+selector
+EOF
+  printf '\r' | timeout 3 bash "$BATS_TEST_TMPDIR/menu_buggy.sh" >/dev/null 2>&1
+  [ "$(wc -l < "$BATS_TEST_TMPDIR/counter_buggy")" -eq 2 ]
+}
+
+@test "no mod-files script (other than the vendored cr3nroll.sh) ends with a redundant selector call" {
+  offenders=""
+  for f in "$ROOT_DIR"/mod-files/usr/bin/*.sh; do
+    [[ "$(basename "$f")" == "cr3nroll.sh" ]] && continue
+    if [[ "$(tail -n1 "$f")" == "selector" ]] && grep -qE '^\s*full_menu\s*$' "$f"; then
+      offenders="$offenders $f"
+    fi
+  done
+  [ -z "$offenders" ]
+}

--- a/test/libmosh.bats
+++ b/test/libmosh.bats
@@ -9,6 +9,14 @@
 
 setup() {
   ROOT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  # The full_menu/selector dispatch tests below exercise real vt-mosh.sh-style
+  # scripts, which end with `tput cnorm`. Many non-interactive shells default
+  # $TERM to "dumb", which has no cursor-control capabilities, so tput fails
+  # there; since these tests don't wrap the call in bats' `run`, that failure
+  # gets misread as the dispatch itself failing. Force a real terminfo entry
+  # so the tests reflect dispatch behavior only, regardless of what $TERM the
+  # shell running bats happened to inherit.
+  export TERM=xterm
   # libmosh.sh reads a few device-only files at the top (stateful, /.branch,
   # /usr/share/misc/shflags, ...) that don't exist off-device; those failures
   # are harmless (the corresponding variables just end up empty) but bats


### PR DESCRIPTION
# Summary

Centralizes error handling, confirmations, and logging across Modmium's mod-files scripts; adds tests and CI; adds a few new features (Health Check, repo picker); fixes several real bugs found along the way.

# Bug fixes

localacc.sh called an undefined fail(), silently marking a failed dependency install as successful
Nearly every menu script double-dispatched the selected action (full_menu already fires it internally, but scripts also called selector again)
"Change ChromeOS Version" kept reporting the old branch after a reinstall instead of the one just installed
A bats test flake under TERM=dumb, unrelated to the behavior it was testing

# Centralization

Shared constants, fail(), confirm_destructive()/confirm_irreversible(), log_action(), and run_with_feedback() moved into libmosh.sh instead of duplicated per-script
Every destructive or irreversible action now warns and confirms before running; no more long silent operations

# New features

Health Check self-test tool (Misc → Health Check)
Repo picker: "Update Modmium" / "Change ChromeOS Version" can now pull from a custom owner/repo, not just the hardcoded one

# Tests & CI

16-test bats suite covering the new shared helpers and the menu double-dispatch fix
CI running syntax checks, shellcheck, and the test suite on every push