### PR TITLE
feat. extension policy force install detection

### DIFF
--- a/mod-files/usr/bin/mosh-upol.sh
+++ b/mod-files/usr/bin/mosh-upol.sh
@@ -78,7 +78,7 @@ EOF
   echo -ne "${G}Install uBlock Origin MV3? [Y/n]: ${N}"
   read -r install_ublock
 
-  recommend_force_ids=("johiffgefcnfiddcakohlcpebgpidnji") # TODO: add the id for Securly Classroom
+  recommend_force_ids=("johiffgefcnfiddcakohlcpebgpidnji" "hkobaiihndnbfhbkmjjfbdimfbdcppdh") # TODO: add the id for Securly Classroom
 														   # i think this would also fix issue #58
 
   found_ids=()

--- a/mod-files/usr/bin/mosh-upol.sh
+++ b/mod-files/usr/bin/mosh-upol.sh
@@ -78,11 +78,38 @@ EOF
   echo -ne "${G}Install uBlock Origin MV3? [Y/n]: ${N}"
   read -r install_ublock
 
+  recommend_force_ids=("johiffgefcnfiddcakohlcpebgpidnji") # TODO: add the id for Securly Classroom
+														   # i think this would also fix issue #58
+
+  found_ids=()
+  for id in "${recommend_force_ids[@]}"; do
+    if grep -q "$id" /root/policy.json; then
+      found_ids+=("$id")
+    fi
+  done
+
+  if [[ ${#found_ids[@]} -gt 0 ]]; then
+	echo -e "${G}These extension IDs have been found in the force install list:${N}"
+	for id in "${found_ids[@]}"; do
+      echo -e "  - ${B}$id${N}"
+    done
+	echo -ne "${N}These extensions are ${R}known to break${N} when not set to force install. ${G}Would you like to set them to force install? [Y/n]: ${N}"
+	read -r force_exts
+  fi
+
   if [[ $install_ublock =~ ^[Nn]$ ]]; then
     INSTALL_UBLOCK=0
   else
     INSTALL_UBLOCK=1
   fi
+
+  if [[ $force_exts =~ ^[Nn]$ ]]; then
+    FORCE_EXTS=0
+  else
+    FORCE_EXTS=1
+  fi
+
+
 
   rm -rf /usr/local/share/policy-test-tool
   cp -r /usr/share/.policy-test-tool /usr/local/share/policy-test-tool
@@ -92,7 +119,9 @@ EOF
   python policy_dump_converter.py --input-dump /root/policy.json --output-policies extracted.json --policy-user "$email" >/dev/null 2>&1 || fail "${R}Failed to extract policies, do you have a policy.json?${N}"
 
   UBLOCK_FLAG=""
+  FORCE_EXTS_FLAG=""
   [[ "$INSTALL_UBLOCK" == "1" ]] && UBLOCK_FLAG="--ublock"
+  [[ "$FORCE_EXTS" == "1" ]] && UBLOCK_FLAG="--force-install-exts $(IFS=,; echo "${found_ids[*]}")"
 
   echo -e "${B}Building policies.json...${N}"
   python build_policies.py \
@@ -100,6 +129,7 @@ EOF
     --policy-source /root/policy.json \
     --email "$email" \
     $UBLOCK_FLAG \
+	$FORCE_EXTS_FLAG \
     --output /usr/local/share/policy-test-tool/policies.json \
     || fail "${R}Failed to build policies.json${N}"
 

--- a/mod-files/usr/share/.policy-test-tool/build_policies.py
+++ b/mod-files/usr/share/.policy-test-tool/build_policies.py
@@ -114,7 +114,7 @@ def main():
     user["ExtensionSettings"] = build_ext_settings(
         user.get("ExtensionInstallForcelist", []),
         args.ublock,
-        args.force-install-exts,
+        args.force_install_exts,
     )
 
     result = {

--- a/mod-files/usr/share/.policy-test-tool/build_policies.py
+++ b/mod-files/usr/share/.policy-test-tool/build_policies.py
@@ -46,7 +46,7 @@ PASSTHROUGH_POLICIES = [
     "WebAppInstallForceList",
 ]
 
-def build_ext_settings(forcelist, install_ublock):
+def build_ext_settings(forcelist, install_ublock, force_exts):
     ext_settings = {}
     for entry in forcelist:
         if ";" in entry:
@@ -55,7 +55,10 @@ def build_ext_settings(forcelist, install_ublock):
             ext_id = entry
             update_url = "https://clients2.google.com/service/update2/crx"
         entry_dict = ext_settings.get(ext_id, {})
-        entry_dict["installation_mode"] = "normal_installed"
+        if ext_id in force_exts:
+            entry_dict["installation_mode"] = "force_installed"
+        else:
+            entry_dict["installation_mode"] = "normal_installed"
         entry_dict["update_url"] = update_url
         ext_settings[ext_id] = entry_dict
 
@@ -67,12 +70,16 @@ def build_ext_settings(forcelist, install_ublock):
 
     return ext_settings
 
+def ext_list(s):
+    return [i.strip() for i in s.split(",")] if s else []
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--extracted", required=True, help="Path to extracted.json")
     parser.add_argument("--policy-source", required=True, help="Path to original policy.json (for passthrough fields)")
     parser.add_argument("--email", required=True, help="Target user email")
     parser.add_argument("--ublock", action="store_true", help="Install uBlock Origin")
+    parser.add_argument("--force-install-exts", type=ext_list, help="IDs to keep on force install separated by commas")
     parser.add_argument("--output", required=True, help="Output policies.json path")
     args = parser.parse_args()
 
@@ -107,6 +114,7 @@ def main():
     user["ExtensionSettings"] = build_ext_settings(
         user.get("ExtensionInstallForcelist", []),
         args.ublock,
+        args.force-install-exts,
     )
 
     result = {


### PR DESCRIPTION
looks in the policy for extensions that break when not set to `force_installed` and asks the user during user policy editor if they want to keep those extensions on force. will fix #64 and might fix #58 if we can get the extension id. the extension ids that are checked are in the variable `recommend_force_ids` in the file `mod-files/usr/bin/mosh-upol.sh`

if there are any things that can improve this or any bugs please lmk im very bad at finding issues